### PR TITLE
[M4] Close the local evidence probe on the COCO restricted pilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,30 @@ For multi-file, architecture-affecting, or ambiguous tasks:
 
 ---
 
+## Communication and execution defaults
+
+Unless the user explicitly asks otherwise:
+
+- respond in Chinese by default
+- treat heavy-compute work, including formal training, large-scale export, and full restricted-pilot validation, as Linux-server workflows
+- treat the local workspace as a code-editing and lightweight-validation environment, not as a substitute for the full data-mirror environment
+- when a task introduces a new experiment, rerun, or audit command, append the exact command to `docs/run_order.md` before execution
+- if `docs/run_order.md` does not exist, create it under `docs/` and keep the log chronological
+- write each command group with a short comment above it, and include a timestamped heading plus purpose / environment / output-root notes when relevant
+- do not overwrite earlier run-order entries; preserve historical commands so the log remains chronological
+
+When a task depends on a complete dataset mirror or server-side mount, for example the full BR-Gen forged-image mirror, do not use a local partial run as proof of end-to-end correctness. Local validation may still be used to verify:
+
+- code paths
+- CLI behavior
+- config parsing
+- unit tests
+- environment-specific failure modes
+
+If the required mirror or mount is missing locally, report that as an environment limitation instead of inferring a code defect or a successful experiment.
+
+---
+
 ## What this repository expects from agents
 
 Always try to:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # AIGC-Detection
-My AIGC-Detection
+
+Local evaluation utilities for staged AIGC detection experiments.
+
+## Environment
+
+Use a clean Python `3.10` or `3.11` environment for the M2/M3 strong-baseline
+path. The Community-Forensics dependency stack is not maintained for older
+Python 3.8 environments.
+
+Install the repository environment before running M2/M3 scripts:
+
+```bash
+pip install -r requirements.txt
+```
+
+If you are reusing an older environment and hit array / image import issues,
+upgrade the core array and image stack explicitly before running the
+Community-Forensics export path:
+
+```bash
+pip install --upgrade "numpy>=1.24,<2.0" "Pillow>=10,<13"
+```
+
+The root `requirements.txt` includes the repo-local dependencies and the
+frozen `external/Community-Forensics/requirements.txt` stack used by the
+strong-baseline export path.

--- a/configs/model/local_module.yaml
+++ b/configs/model/local_module.yaml
@@ -1,0 +1,4 @@
+model:
+  local_module:
+    type: topk
+    k: 16

--- a/docs/contracts/local_module_contract.md
+++ b/docs/contracts/local_module_contract.md
@@ -1,0 +1,251 @@
+# local_module_contract
+
+## Contract Title
+
+- Contract ID: `contract_m4_local_module_probe_coco_restricted_pilot`
+- Related stage / milestone: `M4: Local Evidence Probe on COCO Restricted Pilot`
+- Status:
+  - [x] frozen
+  - [ ] proposed
+  - [ ] revised
+  - [ ] retired
+- Owner:
+  - human research owner
+  - codex M4 execution
+- Last updated: `2026-04-02`
+
+## 1. Purpose
+
+This contract freezes the M4 probe path for the currently verified Community
+Forensics ViT baseline.
+
+The goal is narrow:
+- test whether localized evidence can help the known weak slices from M3
+- do not change the baseline backbone
+- do not turn the probe into a new model or a training milestone
+
+M4 is a failure-explanation and minimal-fix probe, not a benchmark claim.
+
+---
+
+## 2. M4 Scope Clarification
+
+- The local evidence module is introduced as an inference-time probe path.
+- No training recipe or optimization claim is included in this milestone.
+- Hard top-k selection is acceptable because differentiability is out of scope.
+
+This module is NOT a new model.
+This module is a probe for localized failure.
+
+---
+
+## 3. What This Contract Covers
+
+Current contract scope:
+- COCO-only restricted pilot
+- current verified CF-ViT baseline path
+- patch-token-only local evidence scoring
+- residual fusion between CLS/global and local evidence
+- CLI-gated activation with YAML parameters only
+- baseline export compatibility and regression protection
+
+---
+
+## 4. Frozen Objectives
+
+The following goals are fixed for M4:
+
+- Objective 1:
+  - preserve the current Community Forensics baseline path unchanged when the
+    probe is disabled
+- Objective 2:
+  - insert the local module only between token features and the unchanged head
+- Objective 3:
+  - measure whether the probe improves the known weak localized slices on the
+    COCO restricted pilot
+
+These objectives must not be reinterpreted during normal implementation work.
+
+---
+
+## 5. Frozen Inputs / Outputs
+
+### Inputs
+- Input A:
+  - source:
+    - `forward_features(x)` from the verified CF-ViT backbone
+  - expected form:
+    - `X ∈ R^{B×(1+N)×D}`
+  - meaning:
+    - token sequence with CLS token at index `0` and patch tokens at
+      `1:`
+- Input B:
+  - source:
+    - local evidence module parameters
+  - expected form:
+    - `model.local_module.type`
+    - `model.local_module.k`
+  - meaning:
+    - probe configuration only, not activation
+- Input C:
+  - source:
+    - CLI flag `--use-local-module`
+  - expected form:
+    - boolean switch
+  - meaning:
+    - single activation source for the probe path
+
+### Outputs
+- Output A:
+  - location / API / artifact:
+    - wrapper logit output
+  - expected form:
+    - `logit ∈ R^{B×1}`
+  - meaning:
+    - classification score from the unchanged head
+- Output B:
+  - location / API / artifact:
+    - repo-compatible prediction JSONL
+  - expected form:
+    - same baseline schema, with optional local-module provenance in `meta`
+  - meaning:
+    - export path stays compatible with existing runner contracts
+
+---
+
+## 6. Frozen Interfaces
+
+Frozen interfaces:
+- Interface 1:
+  - `LocalEvidenceModule.forward(patch_tokens)` consumes patch tokens only
+  - patch tokens are `X[:, 1:, :]`
+- Interface 2:
+  - `f_global = X[:, 0, :]`
+  - `f_local = LocalEvidenceModule(patch_tokens)`
+  - `f_out = f_global + f_local`
+  - no concat, no gating, no attention, no extra head
+- Interface 3:
+  - `--use-local-module` is the only activation switch
+  - YAML must not contain `model.use_local_module`
+- Interface 4:
+  - YAML is parameter-only
+  - allowed keys are `model.local_module.type` and `model.local_module.k`
+- Interface 5:
+  - baseline mode must be numerically equivalent to the original CF ViT
+    classifier within tolerance
+- Interface 6:
+  - top-k behavior:
+    - `k <= 0` -> error
+    - `N == 0` -> error
+    - `k > N` -> clamp to `N`
+    - `N == 1` -> trivial selection
+
+Allowed tolerance:
+- internal refactor that preserves the frozen meaning above
+- doc clarification without semantic change
+- non-breaking validation additions
+
+Not allowed:
+- renaming or changing the frozen fusion rule
+- silent semantic drift in token selection
+- hidden activation control through YAML
+- changing the head interface
+- introducing training-only behavior
+
+---
+
+## 7. Allowed Change Window
+
+The following changes are allowed within this stage:
+
+- implementation detail improvements that do not change semantics
+- focused bug fixes that restore intended behavior
+- additional tests / validation
+- documentation sync
+- narrow refactors that preserve interfaces and outputs
+
+Project-specific allowed changes:
+- add the local module wrapper and exporter plumbing
+- add config and docs for the probe path
+- add slice-aware comparison notes for COCO restricted pilot analysis
+
+---
+
+## 8. Explicitly Forbidden Changes
+
+The following changes must not be made during this stage without explicit
+approval:
+
+- redesigning the backbone
+- adding concat, gating, attention, or a new head
+- changing evaluation or metric semantics
+- expanding the dataset scope beyond COCO-only restricted pilot
+- introducing ImageNet / Places negatives
+- turning the probe into a benchmark claim
+
+---
+
+## 9. Validation Contract
+
+The following validation expectations are frozen for this stage:
+
+- required local checks:
+  - `torch.allclose` baseline equivalence test with `atol=1e-6`
+  - top-k selection and clamp tests
+  - empty-token and invalid-`k` error tests
+  - YAML parameter-only config rejection test
+  - exporter flag plumbing test
+- required focused tests:
+  - repository unit tests covering the new module and exporter path
+- required manual sanity checks:
+  - review the contract, plan, and results docs before running the COCO pilot
+- optional broader checks:
+  - the later COCO restricted-pilot comparison using the existing eval chain
+
+---
+
+## 10. Stop Conditions
+
+If any of the following happen, stop and report:
+
+- the baseline path no longer matches the original CF ViT behavior when the
+  probe is off
+- token layout is ambiguous or CLS / patch positions cannot be trusted
+- the requested change needs concat, gating, attention, or a new head
+- YAML is being used as an activation source
+- the work would expand beyond the verified CF-ViT path
+
+---
+
+## 11. Change Control
+
+If this contract must change, do not edit code first.
+
+Use this process:
+
+1. identify the exact frozen item that no longer holds
+2. explain why it blocks correctness or execution
+3. propose the smallest revision that would unblock M4
+4. obtain human approval
+5. update this contract explicitly before continuing
+
+---
+
+## 12. Linked Documents
+
+Relevant docs:
+- `docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md`
+- `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.2_local_module_integration.md`
+- `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.3_coco_only_comparison_and_slice_audit.md`
+- `docs/plan/milestone4_local_module.md`
+- `docs/exp/local_module_results.md`
+
+## 13. Repository Workflow Note
+
+- Full COCO restricted-pilot runs and multi-seed audits are expected to execute
+  on Linux servers with the complete BR-Gen forged-image mirror.
+- Local validation is limited to code paths, CLI behavior, config parsing, and
+  unit tests.
+- New experiment commands should be appended to `docs/run_order.md` with a
+  timestamped heading and a short note; keep historical commands instead of
+  overwriting them.

--- a/docs/data/DATA_LAYOUT.md
+++ b/docs/data/DATA_LAYOUT.md
@@ -80,6 +80,8 @@ data/
           images/
           masks/
           predictions/
+        formal/
+          manifest/
       snapshots/
     placeholders/
   external/
@@ -161,6 +163,17 @@ Expected contents:
 - `masks/` when available
 - `predictions/` for dummy or baseline exports
 
+### `data/mirrored/br_gen/subsets/formal/`
+
+Use this for formal M3 manifest artifacts derived from the official external BR-Gen root.
+
+Expected contents:
+- `manifest/`
+
+Important:
+- this folder stores manifests and layout-audit outputs, not a copied full BR-Gen raw tree
+- the official BR-Gen raw data should remain at the external Linux source root
+
 ### `data/mirrored/br_gen/snapshots/`
 
 Use this for lightweight directory snapshots, notes, or inventories copied from the server.
@@ -228,6 +241,24 @@ Optional but useful:
 - `masks/`
 - `predictions/dummy_predictions.jsonl`
 - `predictions/community_forensics_predictions.jsonl`
+
+For formal M3 localized validation, generate manifests from the official external source root into:
+
+```text
+data/mirrored/br_gen/subsets/formal/
+  manifest/
+    clean_manifest.jsonl
+    formal_manifest.jsonl
+    layout_audit.json
+```
+
+Recommended command:
+
+```text
+python scripts/prepare_br_gen_m3_formal.py --source-root /media/ruanzhengsen/02EE2033DCBE79181/xyj/BRGen/BR-Gen --output-root data/mirrored/br_gen/subsets/formal
+```
+
+This keeps the full raw dataset outside the repository while still creating traceable formal manifests.
 
 If the first source drop arrives outside the recommended layout, for example under:
 

--- a/docs/exp/local_module_results.md
+++ b/docs/exp/local_module_results.md
@@ -1,0 +1,176 @@
+# M4 Local Evidence Module Results
+
+## Status
+
+Measured on the COCO-only restricted pilot.
+
+This is diagnostic evidence for the M4 probe path, not a benchmark claim.
+
+## Inputs Audited
+
+- Baseline export: `outputs/m4/restricted_pilot/predictions_baseline.jsonl`
+- Local-module export: `outputs/m4/restricted_pilot/predictions_local_module.jsonl`
+- Baseline eval: `outputs/m4/restricted_pilot/eval_baseline/summary.json`
+- Local-module eval: `outputs/m4/restricted_pilot/eval_local_module/summary.json`
+- Baseline localized audit: `outputs/m4/restricted_pilot/eval_baseline/localized_failure_summary.json`
+- Local-module localized audit: `outputs/m4/restricted_pilot/eval_local_module/localized_failure_summary.json`
+- Baseline coverage audit: `outputs/m4/restricted_pilot/eval_baseline/localized_coverage_summary.json`
+- Local-module coverage audit: `outputs/m4/restricted_pilot/eval_local_module/localized_coverage_summary.json`
+
+## Credibility Check
+
+- Both prediction files contain `275000` rows.
+- `sample_id` order is identical between the two prediction files.
+- Both runs use the same manifest and the same `restricted_pilot` eval scope.
+- Coverage structure is identical:
+  - `background` / `stuff`
+  - `small` / `medium` / `large`
+  - `subtlety` remains blocked in both runs
+- The only visible prediction-side difference in metadata is the explicit
+  `meta.local_module` field in the local-module output.
+
+This makes the comparison fair enough to interpret as a probe-vs-baseline
+readout.
+
+## Core Results
+
+### Overall
+
+| Metric | Baseline | Local module | Delta |
+| --- | ---: | ---: | ---: |
+| Accuracy | 0.5384181818181818 | 0.5507272727272727 | +0.0123090909090909 |
+| AUROC | 0.8754560336 | 0.8773497972 | +0.0018937636 |
+| fake_recall | 0.4924 | 0.505992 | +0.013592 |
+
+### Region slices
+
+| Slice | Baseline fake_recall | Local fake_recall | Delta | Interpretation |
+| --- | ---: | ---: | ---: | --- |
+| background | 0.77644 | 0.79616 | +0.01972 | Still easy; probe does not destabilize it |
+| stuff | 0.175 | 0.1856 | +0.0106 | Weak slice improved, but only modestly |
+
+### Edit-area slices
+
+| Slice | Baseline fake_recall | Local fake_recall | Delta | Interpretation |
+| --- | ---: | ---: | ---: | --- |
+| small | 0.0 | 0.0008988764044943821 | +0.0008988764044943821 | Still effectively blocked |
+| medium | 0.01764705882352941 | 0.021148459383753503 | +0.003501400560224093 | Small positive movement, still very weak |
+| large | 0.5822566752799311 | 0.6002460932693491 | +0.01798941798941798 | Already strong; now slightly higher |
+
+## Slice-Aware Interpretation
+
+Observed facts:
+- The local probe changes model behavior.
+- The overall numbers move up slightly.
+- `background` remains an easy regime and stays strong.
+- `stuff` improves modestly.
+- `small` and `medium` improve only marginally and remain weak.
+
+What this does not show:
+- It does not show a decisive rescue of the localized blind spots.
+- It does not show a large, isolated gain on `stuff` / `small` / `medium`.
+- It does not show evidence that the hard top-k probe is already the final form
+  of the method.
+
+Mechanistic readout, limited to this evidence:
+- The no-train probe is not inert.
+- The residual add path can move decisions in the expected direction.
+- The signal is weak enough that the current hard top-k formulation may still
+  be too rigid to exploit local evidence fully.
+
+## Trust Notes
+
+- `support.low_support` is `false` for the relevant slices.
+- The result is not explained away by sample scarcity.
+- There is no manifest / eval mismatch in the audited outputs.
+- The result remains restricted-pilot diagnostic evidence only.
+
+## Conclusion
+
+M4 produced a credible probe-vs-baseline readout.
+
+The local module is not useless: it shifts the decision surface in the expected
+direction and improves overall and slice-level fake_recall slightly.
+
+However, the gain is small and not sharply concentrated on the weakest slices.
+This supports closing M4 as a capability milestone, but not promoting the current
+hard top-k probe directly into a training claim.
+
+## Multi-Seed Audit Attempt
+
+An M4 multi-seed stability audit was executed through
+`scripts/run_m4_multi_seed_audit.py` in this workspace.
+
+Observed outcome:
+- run id: `m4_multi_seed_20260402T133603Z_unknown`
+- requested seeds: `0,1,2,3,4`
+- successful seeds: `0`
+- failed seeds: `5`
+- aggregate stats: unavailable because no seed reached a successful export/eval
+
+Failure pattern:
+- all seeds failed in the export stage
+- the first missing asset reported by the manifest loader was
+  `D:\home\workspace\AIGC\data\BRGen\BR-Gen\Forged\BrushNet\Background\COCO\000000000772_background.png`
+- the local workspace contains the corresponding mask file, but not the forged
+  image file
+
+Interpretation:
+- this is a data-availability blocker, not a model-behavior result
+- no seed-stability conclusion can be drawn from this workspace run
+- the single-run positive signal remains the only usable M4 diagnostic evidence
+
+## Multi-Seed Stability Audit
+
+The earlier workspace attempt above is historical and is superseded by a
+successful Linux rerun.
+
+Audited run:
+- run id: `m4_multi_seed_20260403T024452Z_unknown`
+- output root: `outputs/m4/multi_seed_audit/m4_multi_seed_20260403T024452Z_unknown`
+- successful seeds: `5/5`
+- failed seeds: `0/5`
+
+Baseline control:
+- reused `outputs/m4/restricted_pilot/eval_baseline`
+- same manifest, same restricted-pilot eval scope, same slice support
+- baseline sample count: `275000`
+
+### Aggregate Readout
+
+| Metric | Baseline | Local mean ± std | Delta mean | Improved seeds | Interpretation |
+| --- | ---: | ---: | ---: | ---: | --- |
+| overall_accuracy | 0.5384181818181818 | 0.5446567272727273 ± 0.0039427897158993315 | +0.006238545454545497 | 5/5 | Stable overall lift |
+| overall_auroc | 0.8754560336 | 0.876344663584 ± 0.0011314559473426316 | +0.0008886299839999667 | 4/5 | Weak positive, one seed slightly below baseline |
+| overall_fake_recall | 0.4924 | 0.49928800000000007 ± 0.004357513970144001 | +0.006888000000000061 | 5/5 | Stable overall lift |
+| background_fake_recall | 0.77644 | 0.787992 ± 0.005454935380002233 | +0.011552000000000007 | 5/5 | Easy regime preserved and improved |
+| stuff_fake_recall | 0.175 | 0.181448 ± 0.003378686135171478 | +0.006448000000000009 | 5/5 | Stable weak-slice gain |
+| small_fake_recall | 0.0 | 0.0006292134831460674 ± 0.00024616744157535553 | +0.0006292134831460674 | 5/5 | Measurable but still effectively blocked |
+| medium_fake_recall | 0.01764705882352941 | 0.02042016806722689 ± 0.0007304428465213064 | +0.002773109243697478 | 5/5 | Stable but still weak |
+| large_fake_recall | 0.5822566752799311 | 0.5928091546696198 ± 0.005281708533255125 | +0.01055247938968873 | 5/5 | Positive sanity check |
+
+### Stability Readout
+
+- `stuff`, `small`, `medium`, and `background` all moved in the same direction
+  across all five seeds.
+- `small` is still practically blocked in absolute terms, even though the
+  direction is consistent.
+- `overall_auroc` is the only mixed metric; it is positive on average, but the
+  effect size is smaller than the run-to-run variation.
+- `subtlety` stayed `blocked` for all five seeds.
+
+### Trust Notes
+
+- `support.low_support` is `false` for the relevant slices.
+- There is no evidence of sample scarcity or manifest mismatch.
+- The effect is therefore not explained away by low support.
+
+### Final Reading
+
+- The no-train local probe is seed-stable on the blind-spot slices.
+- The effect size is modest, but it is consistent and not a lucky seed.
+- M4 can be closed as capability complete + seed-stability audited diagnostic
+  evidence.
+- M5 is now justified as a separate milestone only if the project wants to
+  test whether trainable local scoring / soft aggregation can amplify this
+  stable signal.

--- a/docs/gitflow/MILESTONE_ROADMAP.md
+++ b/docs/gitflow/MILESTONE_ROADMAP.md
@@ -4,8 +4,13 @@
 
 This document is the current macro-level milestone source of truth.
 
-它替代了此前过于激进、把 baseline implementation、qualification、localized validation 混在一起的旧拆分。
-新的规划先补评测底座，再接 baseline，最后做真正的验证实验。
+当前路线已经从“先追 formal localized benchmark”调整成“两阶段推进”：
+- 先把 restricted-pilot 证据线跑实
+- 再沿 COCO-only engineering line 做方法验证
+
+因此 roadmap 必须显式区分：
+- benchmark 级结论
+- engineering 级方法验证
 
 ---
 
@@ -14,56 +19,71 @@ This document is the current macro-level milestone source of truth.
 ### M1: Data and Metric Pipeline Bootstrap
 
 目标：
-- 先把验证实验的底座搭起来，而不是直接跑强 baseline。
+- 先把 localized eval 所需的数据、schema、metric、artifact contract 建起来
 
 核心内容：
 - localized eval data pipeline
-- full-image / localized 的统一 sample schema
-- clean / degraded / slice 元信息读取
+- full-image / localized unified sample schema
+- clean / degraded / slice metadata loading
 - metric pipeline
 - result / artifact schema
-- 小样本 smoke check
-
-为什么先做这个：
-- 当前项目几乎没有可执行实验基础设施
-- 没有 data pipeline 和 metric pipeline，就无法“正确验证”
-- 这一步的目标是让后续 baseline integration 有稳定承载面
+- smoke checks
 
 ### M2: Community Forensics Integration
 
 目标：
-- 把 Community Forensics 作为 baseline 候选接入当前 pipeline，并确认其开源实现至少能正常运行、推理和被评测。
+- 将 Community Forensics 作为 strong baseline 候选接入当前 repo pipeline
 
 核心内容：
-- 接通 Community Forensics 开源仓库或其关键实现
-- 对齐输入输出与当前 repo 的 data / metric pipeline
-- 跑 inference / eval path 的最小 sanity check
-- 明确哪些部分借用它的方法定义，哪些不需要复刻其论文原始 eval protocol
-
-边界：
-- M2 不是完整复现 Community Forensics 论文的评测体系
-- M2 的重点是“在本项目协议下可接入、可运行、可被评测”
+- baseline adapter
+- repo-compatible prediction export
+- smoke fixture and runner sanity
+- M2 contract freeze and integration closeout
 
 ### M3: Strong Baseline Localized Failure Validation
 
 目标：
-- 在你的 localized eval protocol 下，正式验证 strong baseline 是否仍然存在结构性 localized failure。
+- 在当前 repo contract 下判断 strong baseline 是否存在结构化 localized failure
+
+实际收口状态：
+- expanded full-COCO `restricted_pilot` 已完成
+- formal M3 未完成，也不再作为当前主线继续推进
+- M3 当前按“close with documented limitations”处理
+- M3 的有效产出是一张 restricted-pilot 级 failure evidence map
+
+当前可复用结论：
+- `stuff` 区域是稳定 weak slice
+- `small / medium` edit area 是稳定 weak slice
+- `background` 仍然是 easy regime
+
+### M4: Community Forensics Local Module on COCO Engineering Line
+
+目标：
+- 在 Community Forensics baseline 之上接入一个 local module
+- 仅在 `COCO-only restricted_pilot` 工程线上判断它是否改善 M3 已识别的 weak slices
 
 核心内容：
-- 在大量 localized edit 测试样本上评测 baseline
-- 报 overall + slice
-- 分 clean / degraded
-- 回答 strong baseline 是否仍然在 localized edit 上系统性不足
-- 为是否进入 local branch + consistency 提供决策依据
+- freeze M4 的 COCO-only engineering boundary
+- 找到 local module 的最小集成点
+- baseline vs local-module 对比
+- 重点看：
+  - `stuff`
+  - `small / medium` edit area
+  - degradation 下的 slice 行为
+
+边界：
+- 不追 formal M3
+- 不引入 ImageNet / Places negatives
+- 不做 benchmark overclaim
 
 ---
 
 ## Planning Rule
 
-从现在开始，macro planning 按下面顺序走：
+当前宏观顺序调整为：
+1. `M1` 建 data / metric pipeline
+2. `M2` 接 Community Forensics baseline
+3. `M3` 建 restricted-pilot 级 failure evidence
+4. `M4` 在 COCO-only engineering line 上验证 local module
 
-1. `M1` 先立 data / metric pipeline
-2. `M2` 再接 Community Forensics baseline
-3. `M3` 最后做正式验证实验
-
-不要再把这三类工作合并到一个 milestone 里。
+不要把当前 M4 误写成 formal benchmark continuation。

--- a/docs/gitflow/issues/m2_community_forensics_integration/README.md
+++ b/docs/gitflow/issues/m2_community_forensics_integration/README.md
@@ -6,7 +6,11 @@
   - `https://github.com/re-tourist/AIGC-Detection/milestone/3`
 
 - Issue docs:
-  - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.1_intake_and_contract.md`
-  - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.2_prediction_adapter.md`
-  - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.3_runner_sanity.md`
-  - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.4_closeout.md`
+  - `Issue 2.1` / https://github.com/re-tourist/AIGC-Detection/issues/13
+    - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.1_intake_and_contract.md`
+  - `Issue 2.2` / https://github.com/re-tourist/AIGC-Detection/issues/14
+    - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.2_prediction_adapter.md`
+  - `Issue 2.3` / https://github.com/re-tourist/AIGC-Detection/issues/15
+    - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.3_runner_sanity.md`
+  - `Issue 2.4` / https://github.com/re-tourist/AIGC-Detection/issues/16
+    - `docs/gitflow/issues/m2_community_forensics_integration/issue_2.4_closeout.md`

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
@@ -7,14 +7,16 @@
 - Local implementation status:
   - Issue 3.1 through Issue 3.3 are backfilled on GitHub as closed
   - Issue 3.5 is backfilled on GitHub as closed after the expanded restricted-pilot evidence pass
-  - Issue 3.4 remains open because formal M3 is still blocked
-  - Issue 3.0 tracks the gitflow and GitHub backfill work itself and remains open
+  - Issue 3.4 is closed as deferred because the team is not continuing the
+    formal M3 line before M4
+  - Issue 3.0 tracks the gitflow and GitHub backfill work itself and is now
+    closed
 
 - Issue docs and GitHub sync placeholders:
   - Issue 3.0
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md`
     - GitHub: #17 `https://github.com/re-tourist/AIGC-Detection/issues/17`
-    - state: `OPEN`
+    - state: `CLOSED`
   - Issue 3.1
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md`
     - GitHub: #18 `https://github.com/re-tourist/AIGC-Detection/issues/18`
@@ -30,7 +32,7 @@
   - Issue 3.4
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md`
     - GitHub: #21 `https://github.com/re-tourist/AIGC-Detection/issues/21`
-    - state: `OPEN`
+    - state: `CLOSED`
   - Issue 3.5
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md`
     - GitHub: #22 `https://github.com/re-tourist/AIGC-Detection/issues/22`

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
@@ -1,0 +1,37 @@
+# M3 GitHub Issue Index
+
+- Milestone doc:
+  - `docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md`
+- GitHub milestone:
+  - `https://github.com/re-tourist/AIGC-Detection/milestone/4`
+- Local implementation status:
+  - Issue 3.1 through Issue 3.3 are implemented and should be backfilled as closed
+  - Issue 3.5 is implemented and should be backfilled as closed after the expanded restricted-pilot evidence pass
+  - Issue 3.4 remains open because formal M3 is still blocked
+  - Issue 3.0 tracks the gitflow and GitHub backfill work itself
+
+- Issue docs and GitHub sync placeholders:
+  - Issue 3.0
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md`
+    - GitHub: pending creation
+    - state: pending creation
+  - Issue 3.1
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md`
+    - GitHub: pending creation
+    - state: pending creation
+  - Issue 3.2
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md`
+    - GitHub: pending creation
+    - state: pending creation
+  - Issue 3.3
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md`
+    - GitHub: pending creation
+    - state: pending creation
+  - Issue 3.4
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md`
+    - GitHub: pending creation
+    - state: pending creation
+  - Issue 3.5
+    - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md`
+    - GitHub: pending creation
+    - state: pending creation

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md
@@ -5,33 +5,33 @@
 - GitHub milestone:
   - `https://github.com/re-tourist/AIGC-Detection/milestone/4`
 - Local implementation status:
-  - Issue 3.1 through Issue 3.3 are implemented and should be backfilled as closed
-  - Issue 3.5 is implemented and should be backfilled as closed after the expanded restricted-pilot evidence pass
+  - Issue 3.1 through Issue 3.3 are backfilled on GitHub as closed
+  - Issue 3.5 is backfilled on GitHub as closed after the expanded restricted-pilot evidence pass
   - Issue 3.4 remains open because formal M3 is still blocked
-  - Issue 3.0 tracks the gitflow and GitHub backfill work itself
+  - Issue 3.0 tracks the gitflow and GitHub backfill work itself and remains open
 
 - Issue docs and GitHub sync placeholders:
   - Issue 3.0
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #17 `https://github.com/re-tourist/AIGC-Detection/issues/17`
+    - state: `OPEN`
   - Issue 3.1
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #18 `https://github.com/re-tourist/AIGC-Detection/issues/18`
+    - state: `CLOSED`
   - Issue 3.2
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #19 `https://github.com/re-tourist/AIGC-Detection/issues/19`
+    - state: `CLOSED`
   - Issue 3.3
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #20 `https://github.com/re-tourist/AIGC-Detection/issues/20`
+    - state: `CLOSED`
   - Issue 3.4
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #21 `https://github.com/re-tourist/AIGC-Detection/issues/21`
+    - state: `OPEN`
   - Issue 3.5
     - doc: `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md`
-    - GitHub: pending creation
-    - state: pending creation
+    - GitHub: #22 `https://github.com/re-tourist/AIGC-Detection/issues/22`
+    - state: `CLOSED`

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md
@@ -1,7 +1,8 @@
 # Issue 3.0 — Sync M3 GitHub milestone and issue set
 
 GitHub issue:
-- pending creation
+- #17
+- `https://github.com/re-tourist/AIGC-Detection/issues/17`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.0_github_sync_and_backfill.md
@@ -1,0 +1,62 @@
+# Issue 3.0 — Sync M3 GitHub milestone and issue set
+
+GitHub issue:
+- pending creation
+
+## Background
+
+The repository already contains M3 milestone and issue docs, but GitHub does
+not yet reflect the current M3 execution state. In particular:
+
+- the expanded full-COCO restricted pilot is now complete
+- formal M3 remains blocked
+- M3 issue docs must be synchronized to GitHub without turning GitHub into the
+  only source of truth
+
+This issue exists to track the repo-admin work needed to backfill and sync the
+M3 milestone and issue set.
+
+## Suggested Branch
+
+`codex/stage3-github-sync`
+
+## Goal
+
+Refresh the local M3 gitflow docs, backfill the M3 GitHub milestone and issue
+set, and write issue numbers and URLs back into the repository.
+
+## Tasks
+
+- refresh the M3 milestone doc to match the current restricted-pilot and formal
+  M3 state
+- normalize the M3 issue docs to the fixed GitHub issue-body section order
+- create or update the GitHub milestone `M3: Strong Baseline Localized Failure Validation`
+- create GitHub issues for Issue 3.0 through Issue 3.5 from the repo docs
+- set issue states to match the current source-of-truth status
+- write issue numbers, URLs, and states back into the repo issue index
+
+## Resource Boundary
+
+- repo docs remain the source of truth
+- do not mix code-path changes into this sync work
+- do not overclaim formal M3 completion in GitHub metadata
+
+## Non-Goals
+
+- no model, data, or evaluation logic changes
+- no formal M3 closeout
+- no benchmark interpretation changes beyond syncing the documented state
+
+## Deliverable
+
+- refreshed M3 gitflow docs
+- backfilled GitHub milestone and issue set
+- repo issue index with GitHub issue numbers and URLs
+
+## Acceptance
+
+- the M3 milestone doc reflects the current real state
+- GitHub issues 3.0 through 3.5 exist and map cleanly to repo docs
+- completed issues are backfilled as closed
+- the blocked formal-closeout issue remains open
+- repo docs contain the resulting GitHub identifiers

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md
@@ -1,0 +1,60 @@
+# Issue 3.1 — Freeze M3 contract and audit official BR-Gen raw layout
+
+GitHub issue:
+- pending creation
+
+## Background
+
+M3 starts only after M2 integration is complete. The first task is to freeze the
+formal BR-Gen source-root contract and the raw-layout assumptions needed for
+localized validation.
+
+Current repo truth:
+
+- M2 integration is complete and closed.
+- The official BR-Gen root for M3 is available on Linux:
+  - `/media/ruanzhengsen/02EE2033DCBE79181/xyj/BRGen/BR-Gen`
+- The official source provides raw real, fake, and mask directories only.
+- This work is already implemented locally and should be backfilled to GitHub as
+  completed scope.
+
+## Suggested Branch
+
+`codex/stage3-strong-baseline-localized-validation`
+
+## Goal
+
+Make the official BR-Gen root, raw-layout audit rules, and M3 reporting boundary
+explicit before formal manifest generation and Linux execution.
+
+## Tasks
+
+- freeze the M3 execution contract without changing the frozen M1 contract
+- record the accepted raw-layout rules for fake, mask, and real discovery
+- define hard-stop behavior for ambiguous roots, broken pairings, and unsupported
+  layout patterns
+- sync milestone, issue, and run-order docs to the same contract
+
+## Resource Boundary
+
+- do not change M1 field or metric meaning
+- do not infer new metadata beyond the explicit raw layout
+- do not start formal benchmark claims from smoke artifacts
+
+## Non-Goals
+
+- no Community Forensics reproduction
+- no retraining
+- no Linux full run yet
+
+## Deliverable
+
+- frozen M3 contract doc
+- updated M3 milestone doc
+- explicit issue split and Linux runbook entry point
+
+## Acceptance
+
+- the official BR-Gen root requirement is explicit
+- raw-layout ambiguity rules are explicit
+- M3 stop conditions are written down before code relies on them

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.1_intake_and_contract.md
@@ -1,7 +1,8 @@
 # Issue 3.1 — Freeze M3 contract and audit official BR-Gen raw layout
 
 GitHub issue:
-- pending creation
+- #18
+- `https://github.com/re-tourist/AIGC-Detection/issues/18`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md
@@ -1,0 +1,61 @@
+# Issue 3.2 — Prepare formal BR-Gen manifests and perturbation-aware export
+
+GitHub issue:
+- pending creation
+
+## Background
+
+M3 needs a formal localized manifest path built directly from the official BR-Gen
+root. The existing Community Forensics export path should be reused instead of
+replaced.
+
+Current repo truth:
+
+- the formal manifest builder is implemented
+- the Community Forensics export path is perturbation-aware
+- this scope is already completed locally and should be backfilled to GitHub as a
+  completed issue
+
+## Suggested Branch
+
+`codex/stage3-strong-baseline-localized-validation`
+
+## Goal
+
+Write formal clean and degraded localized manifests from the official BR-Gen
+root, then export repo-compatible prediction JSONL through the existing
+Community Forensics inference path.
+
+## Tasks
+
+- audit the official BR-Gen root before manifest generation
+- generate `clean_manifest.jsonl`, `formal_manifest.jsonl`, and `layout_audit.json`
+- keep the formal source root external and avoid copying the full dataset into
+  the repo
+- make the Community Forensics export path apply fixed perturbations when
+  `meta.perturbation` is present
+- preserve clean-manifest behavior when no perturbation is present
+
+## Resource Boundary
+
+- formal BR-Gen source root must be passed explicitly
+- raw `edit_area_ratio` remains forbidden
+- perturbation strengths are fixed by the M3 contract
+
+## Non-Goals
+
+- no new baseline
+- no new model training
+- no degraded image export cache
+
+## Deliverable
+
+- formal BR-Gen manifest builder
+- perturbation-aware prediction export
+- focused tests for manifest prep and export behavior
+
+## Acceptance
+
+- clean and degraded manifests are deterministic and repo-compatible
+- ambiguous or broken official layouts fail loudly
+- export output remains compatible with the existing prediction JSONL loader

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.2_formal_manifest_and_export.md
@@ -1,7 +1,8 @@
 # Issue 3.2 — Prepare formal BR-Gen manifests and perturbation-aware export
 
 GitHub issue:
-- pending creation
+- #19
+- `https://github.com/re-tourist/AIGC-Detection/issues/19`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md
@@ -1,0 +1,58 @@
+# Issue 3.3 — Add localized-failure sidecar reporting on top of the current runner
+
+GitHub issue:
+- pending creation
+
+## Background
+
+The current minimal runner already writes the frozen M1 artifacts. M3 needs
+additional localized-failure evidence without changing that base contract.
+
+Current repo truth:
+
+- the M3 sidecar is implemented
+- the sidecar now covers generator, region, area, degradation, coverage audit,
+  and failure evidence map outputs
+- this scope is already completed locally and should be backfilled to GitHub as
+  a completed issue
+
+## Suggested Branch
+
+`codex/stage3-strong-baseline-localized-validation`
+
+## Goal
+
+Layer an M3-only localized-failure report on top of the existing runner outputs.
+
+## Tasks
+
+- reuse the existing minimal runner as the first evaluation step
+- compute localized clean metrics and degradation summaries from the same
+  manifest and prediction inputs
+- report `region_type` slices and `edit_area_ratio` bins using explicit masks
+  only
+- keep `subtlety` blocked when explicit metadata is absent
+- write M3 summary JSON, flat CSV, and Markdown report artifacts
+
+## Resource Boundary
+
+- no change to minimal runner artifact semantics
+- no additional core metrics beyond `AUROC`, `Accuracy`, and `fake_recall`
+- no heuristic slice metadata
+
+## Non-Goals
+
+- no benchmark table automation for future stages
+- no calibration or AUPR contract expansion
+
+## Deliverable
+
+- M3 evaluation entry point
+- localized-failure sidecar artifacts
+- focused tests for degradation, region, area-bin, and blocked subtlety behavior
+
+## Acceptance
+
+- the minimal runner artifacts remain intact
+- M3 sidecar artifacts are traceable to the same manifest and predictions
+- slice summaries fail only when the underlying explicit data is missing

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.3_localized_failure_report.md
@@ -1,7 +1,8 @@
 # Issue 3.3 — Add localized-failure sidecar reporting on top of the current runner
 
 GitHub issue:
-- pending creation
+- #20
+- `https://github.com/re-tourist/AIGC-Detection/issues/20`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
@@ -1,7 +1,8 @@
 # Issue 3.4 — Execute formal Linux run and write milestone closeout
 
 GitHub issue:
-- pending creation
+- #21
+- `https://github.com/re-tourist/AIGC-Detection/issues/21`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
@@ -1,4 +1,4 @@
-# Issue 3.4 — Execute formal Linux run and write milestone closeout
+# Issue 3.4 - Formal Linux run and formal closeout path (deferred)
 
 GitHub issue:
 - #21
@@ -8,14 +8,16 @@ GitHub issue:
 
 M3 formal evidence depends on the official BR-Gen root and baseline weights on
 Linux. Local implementation and the completed restricted pilot are not
-sufficient to close the milestone.
+sufficient to establish a formal benchmark claim.
 
 Current repo truth:
 
 - the expanded full-COCO restricted pilot has already been executed
-- formal M3 remains blocked because ImageNet / Places real negatives are still
-  unavailable
-- this issue should remain open on GitHub as the blocked formal closeout issue
+- formal M3 remains unavailable because ImageNet / Places real negatives are
+  still unavailable
+- the project is now moving to M4 on the COCO-only engineering line
+- this issue should be closed as deferred rather than left open as the active
+  next step
 
 ## Suggested Branch
 
@@ -23,41 +25,39 @@ Current repo truth:
 
 ## Goal
 
-Run the full formal localized-failure evaluation on Linux when prerequisites are
-available, then write the milestone closeout.
+Record the deferred formal path cleanly so that M3 can close with documented
+limitations and M4 can start from the restricted-pilot evidence base.
 
 ## Tasks
 
-- confirm formal prerequisites for ImageNet / Places real negatives are
-  available
-- run the full clean and degraded formal manifest flow on Linux
-- export formal predictions and produce base eval plus M3 sidecar artifacts
-- archive formal artifacts and write milestone closeout after the full run
+- record that the expanded `COCO-only restricted_pilot` is the last executed
+  M3 evidence line
+- document why the formal BR-Gen line is not being pursued before M4
 - separate clearly:
-  - already run
-  - implemented but not yet run
-  - Linux-only steps
+  - already run restricted-pilot work
+  - implemented but intentionally unrun formal work
+  - the next active line, which is M4 on COCO-only engineering scope
+- close the GitHub issue as deferred rather than leaving it ambiguous
 
 ## Resource Boundary
 
-- use the frozen official BR-Gen root and M3 perturbation settings
-- do not treat the restricted pilot as formal benchmark evidence
-- do not write closeout text that claims results not yet run
+- do not relabel restricted-pilot results as formal benchmark evidence
+- do not write closeout text that claims the formal line was run
+- do not keep the formal path open as if it were the next required action
 
 ## Non-Goals
 
 - no additional method work
-- no dataset relayout
-- no rerouting through an upstream paper-reproduction harness
+- no forced formal run without restored prerequisites
+- no benchmark overclaim
 
 ## Deliverable
 
-- Linux full-run artifacts
-- M3 closeout doc after formal execution
+- M3 closeout doc with explicit deferred-formal wording
+- a clean handoff into M4 on the COCO-only engineering line
 
 ## Acceptance
 
-- formal prerequisites are explicitly satisfied before execution
-- full run produces formal manifest, predictions, base eval artifacts, and M3
-  sidecar artifacts
-- closeout explicitly states what was actually run and what remains out of scope
+- the repo docs explicitly state that formal M3 was not executed
+- restricted-pilot artifacts remain the only executed evidence base
+- the formal path is closed as deferred, not left in an ambiguous open state

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.4_linux_runs_and_closeout.md
@@ -1,0 +1,62 @@
+# Issue 3.4 — Execute formal Linux run and write milestone closeout
+
+GitHub issue:
+- pending creation
+
+## Background
+
+M3 formal evidence depends on the official BR-Gen root and baseline weights on
+Linux. Local implementation and the completed restricted pilot are not
+sufficient to close the milestone.
+
+Current repo truth:
+
+- the expanded full-COCO restricted pilot has already been executed
+- formal M3 remains blocked because ImageNet / Places real negatives are still
+  unavailable
+- this issue should remain open on GitHub as the blocked formal closeout issue
+
+## Suggested Branch
+
+`codex/stage3-formal-linux-closeout`
+
+## Goal
+
+Run the full formal localized-failure evaluation on Linux when prerequisites are
+available, then write the milestone closeout.
+
+## Tasks
+
+- confirm formal prerequisites for ImageNet / Places real negatives are
+  available
+- run the full clean and degraded formal manifest flow on Linux
+- export formal predictions and produce base eval plus M3 sidecar artifacts
+- archive formal artifacts and write milestone closeout after the full run
+- separate clearly:
+  - already run
+  - implemented but not yet run
+  - Linux-only steps
+
+## Resource Boundary
+
+- use the frozen official BR-Gen root and M3 perturbation settings
+- do not treat the restricted pilot as formal benchmark evidence
+- do not write closeout text that claims results not yet run
+
+## Non-Goals
+
+- no additional method work
+- no dataset relayout
+- no rerouting through an upstream paper-reproduction harness
+
+## Deliverable
+
+- Linux full-run artifacts
+- M3 closeout doc after formal execution
+
+## Acceptance
+
+- formal prerequisites are explicitly satisfied before execution
+- full run produces formal manifest, predictions, base eval artifacts, and M3
+  sidecar artifacts
+- closeout explicitly states what was actually run and what remains out of scope

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md
@@ -1,7 +1,8 @@
 # Issue 3.5 — Expand restricted pilot evidence and failure mapping
 
 GitHub issue:
-- pending creation
+- #22
+- `https://github.com/re-tourist/AIGC-Detection/issues/22`
 
 ## Background
 

--- a/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md
+++ b/docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/issue_3.5_restricted_pilot_evidence_expansion.md
@@ -1,0 +1,89 @@
+# Issue 3.5 — Expand restricted pilot evidence and failure mapping
+
+GitHub issue:
+- pending creation
+
+## Background
+
+The initial COCO-only restricted pilot ran end to end, but the first evidence
+pass was too narrow:
+
+- fake coverage was effectively close to `COCO-only`, `BrushNet-only`,
+  `background-only`
+- edit-area support was heavily concentrated in the `large` bin
+- subtlety remained blocked
+- overall metrics were high, but slice evidence was weak
+
+Current repo truth:
+
+- the active fake cap has been removed
+- the expanded full-COCO restricted pilot has been executed
+- wider coverage, support accounting, and failure-evidence artifacts now exist
+- this scope should be backfilled to GitHub as a completed issue
+
+## Suggested Branch
+
+`codex/stage3-restricted-pilot-evidence-expansion`
+
+## Goal
+
+Expand the COCO-only restricted pilot so that it provides:
+
+- wider slice coverage
+- explicit support accounting
+- a structured failure evidence map
+- a clearer definition of pilot success
+
+## Tasks
+
+- audit and remove the active fake-sample cap in the restricted pilot path
+- preserve the `restricted_pilot` and `COCO-only` boundaries
+- extend the localized sidecar to report:
+  - generator slices
+  - region slices
+  - source slices
+  - edit-area slices
+  - exploratory pairwise slices where support exists
+- add low-support labeling and diagnostic labels
+- generate new analysis artifacts:
+  - `localized_coverage_summary.json`
+  - `coverage_audit.md`
+  - `failure_evidence_map.md`
+- write an explicit restricted-pilot success-criteria document
+
+## Resource Boundary
+
+- allowed:
+  - COCO-only restricted pilot expansion
+  - stronger analysis artifacts
+  - Linux reruns for the expanded restricted pilot
+- not allowed:
+  - ImageNet / Places negatives
+  - formal M3 redefinition
+  - method innovation
+  - benchmark overclaim
+
+## Non-Goals
+
+- formal M3 closeout
+- paper-ready benchmark claim
+- new model training
+- new localized architecture modules
+
+## Deliverable
+
+An expanded restricted pilot that is able to answer:
+
+- which localized slices are covered
+- which slices remain easy
+- which slices show credible failure evidence
+- which slices remain low-support or blocked
+
+## Acceptance
+
+- the active fake cap is auditable and removable
+- expanded restricted pilot preserves `COCO-only` and `restricted_pilot`
+- localized sidecar exposes wider slice coverage
+- low-support slices are explicitly labeled
+- a structured failure evidence map is generated
+- pilot success criteria are written and linked

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/README.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/README.md
@@ -7,21 +7,22 @@
 - Local execution status:
   - M4 issue docs are prepared locally
   - GitHub sync is complete
+  - milestone is closed and issues are closed
 
 - Issue docs and GitHub sync placeholders:
   - Issue 4.1
     - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.1_scope_and_interface.md`
     - GitHub: #23 `https://github.com/re-tourist/AIGC-Detection/issues/23`
-    - state: `OPEN`
+    - state: `CLOSED`
   - Issue 4.2
     - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.2_local_module_integration.md`
     - GitHub: #24 `https://github.com/re-tourist/AIGC-Detection/issues/24`
-    - state: `OPEN`
+    - state: `CLOSED`
   - Issue 4.3
     - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.3_coco_only_comparison_and_slice_audit.md`
     - GitHub: #25 `https://github.com/re-tourist/AIGC-Detection/issues/25`
-    - state: `OPEN`
+    - state: `CLOSED`
   - Issue 4.4
     - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.4_closeout_and_handoff.md`
     - GitHub: #26 `https://github.com/re-tourist/AIGC-Detection/issues/26`
-    - state: `OPEN`
+    - state: `CLOSED`

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/README.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/README.md
@@ -1,0 +1,27 @@
+# M4 Gitflow Issue Index
+
+- Milestone doc:
+  - `docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md`
+- GitHub milestone:
+  - `https://github.com/re-tourist/AIGC-Detection/milestone/5`
+- Local execution status:
+  - M4 issue docs are prepared locally
+  - GitHub sync is complete
+
+- Issue docs and GitHub sync placeholders:
+  - Issue 4.1
+    - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.1_scope_and_interface.md`
+    - GitHub: #23 `https://github.com/re-tourist/AIGC-Detection/issues/23`
+    - state: `OPEN`
+  - Issue 4.2
+    - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.2_local_module_integration.md`
+    - GitHub: #24 `https://github.com/re-tourist/AIGC-Detection/issues/24`
+    - state: `OPEN`
+  - Issue 4.3
+    - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.3_coco_only_comparison_and_slice_audit.md`
+    - GitHub: #25 `https://github.com/re-tourist/AIGC-Detection/issues/25`
+    - state: `OPEN`
+  - Issue 4.4
+    - doc: `docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.4_closeout_and_handoff.md`
+    - GitHub: #26 `https://github.com/re-tourist/AIGC-Detection/issues/26`
+    - state: `OPEN`

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.1_scope_and_interface.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.1_scope_and_interface.md
@@ -1,0 +1,71 @@
+# Issue 4.1 - Freeze M4 scope and local-module interface on the COCO engineering line
+
+GitHub issue:
+- #23
+- `https://github.com/re-tourist/AIGC-Detection/issues/23`
+
+## Background
+
+M3 is being closed as a restricted-pilot-only engineering handoff. The next
+active line is no longer formal validation; it is a COCO-only method
+engineering line built on top of the Community Forensics baseline.
+
+The M3 failure evidence already points to the current weak slices:
+
+- `stuff`
+- `small / medium` edit area
+
+Before implementing a local module, M4 must freeze:
+
+- the active evaluation scope
+- the allowed data boundary
+- the narrowest viable integration point in the current baseline path
+
+## Suggested Branch
+
+`codex/stage4-scope-and-interface`
+
+## Goal
+
+Freeze a minimal and executable M4 scope so that the local module work does not
+silently drift into formal benchmark, data expansion, or metric redefinition.
+
+## Tasks
+
+- confirm that M4 stays inside:
+  - `evaluation_scope = restricted_pilot`
+  - `dataset scope = COCO-only`
+- document the baseline path that M4 will build on
+- identify the narrowest local-module insertion point in the Community
+  Forensics code path
+- define what artifacts the comparison must reuse
+- define what M4 success means for an engineering-line comparison
+
+## Resource Boundary
+
+- allowed:
+  - Community Forensics baseline reuse
+  - local module integration planning
+  - COCO-only restricted-pilot comparisons
+- not allowed:
+  - formal M3 continuation
+  - ImageNet / Places negatives
+  - contract changes to metric semantics
+
+## Non-Goals
+
+- no model-code implementation yet
+- no benchmark claim drafting
+- no paper-result packaging
+
+## Deliverable
+
+- a frozen M4 interface and scope note
+- an explicit list of files and artifacts that the implementation issue must
+  build on
+
+## Acceptance
+
+- the scope is narrow enough that the next issue can code immediately
+- the active comparison boundary is explicit
+- the local module insertion point is concrete, not aspirational

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.2_local_module_integration.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.2_local_module_integration.md
@@ -1,0 +1,58 @@
+# Issue 4.2 - Integrate a local module into the Community Forensics baseline path
+
+GitHub issue:
+- #24
+- `https://github.com/re-tourist/AIGC-Detection/issues/24`
+
+## Background
+
+The baseline path already runs end to end on the COCO-only restricted pilot.
+M4 now needs a local module added on top of that path without breaking the
+existing export, prediction, and evaluation contracts.
+
+## Suggested Branch
+
+`codex/stage4-local-module-integration`
+
+## Goal
+
+Implement the smallest viable local module on top of the Community Forensics
+baseline so that it can be compared fairly against the current baseline under
+the same restricted-pilot contract.
+
+## Tasks
+
+- integrate the local module at the frozen insertion point
+- keep the baseline path available as an unchanged comparison arm
+- make the export path selectable between:
+  - baseline
+  - baseline plus local module
+- preserve manifest, prediction JSONL, and runner compatibility
+- add focused validation for the new path
+
+## Resource Boundary
+
+- allowed:
+  - code changes in the Community Forensics integration path
+  - minimal config or script changes needed for side-by-side comparison
+- not allowed:
+  - evaluation contract changes
+  - new dataset scope
+  - unrelated refactors
+
+## Non-Goals
+
+- no generator-diverse retraining
+- no formal benchmark work
+- no paper-facing result claims
+
+## Deliverable
+
+- a runnable baseline-plus-local-module export path
+- focused validation proving the path is wired correctly
+
+## Acceptance
+
+- both comparison arms run under the same restricted-pilot contract
+- the local module path does not break existing baseline execution
+- the diff stays reviewable and scoped

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.3_coco_only_comparison_and_slice_audit.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.3_coco_only_comparison_and_slice_audit.md
@@ -1,0 +1,59 @@
+# Issue 4.3 - Run COCO-only baseline-vs-local-module comparison and slice audit
+
+GitHub issue:
+- #25
+- `https://github.com/re-tourist/AIGC-Detection/issues/25`
+
+## Background
+
+M3 has already established a failure evidence map on the full-COCO restricted
+pilot. M4 must use that map to judge whether the local module helps on the
+actual weak slices, not just whether overall score changes.
+
+## Suggested Branch
+
+`codex/stage4-coco-comparison-audit`
+
+## Goal
+
+Run a controlled COCO-only restricted-pilot comparison between the baseline and
+the baseline-plus-local-module variant, then audit the slice-level outcome.
+
+## Tasks
+
+- generate predictions for both comparison arms
+- run the existing eval and localized sidecar for both arms
+- compare:
+  - overall metrics
+  - `region_type`
+  - `edit_area_ratio`
+  - degradation slices
+  - the known weak slices from M3
+- separate clearly:
+  - actual improvement
+  - neutral change
+  - regression
+  - inconclusive low-support observations
+
+## Resource Boundary
+
+- use the existing restricted-pilot manifests and sidecar
+- keep the comparison inside COCO-only engineering scope
+- avoid any wording that turns this into a formal benchmark claim
+
+## Non-Goals
+
+- no formal M3 resurrection
+- no new data source integration
+- no paper benchmark packaging
+
+## Deliverable
+
+- comparison artifacts for both arms
+- a slice-level audit describing where the local module helps or fails to help
+
+## Acceptance
+
+- both arms are evaluated under the same contract
+- slice-level conclusions are support-aware
+- the report emphasizes failure axes rather than only overall score

--- a/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.4_closeout_and_handoff.md
+++ b/docs/gitflow/issues/m4_community_forensics_local_module_coco_engineering_line/issue_4.4_closeout_and_handoff.md
@@ -1,0 +1,51 @@
+# Issue 4.4 - Write M4 review, handoff, and closeout for the engineering line
+
+GitHub issue:
+- #26
+- `https://github.com/re-tourist/AIGC-Detection/issues/26`
+
+## Background
+
+If M4 produces a usable baseline-vs-local-module comparison, the result still
+needs to be documented carefully so that future work does not confuse an
+engineering-line result with a formal benchmark claim.
+
+## Suggested Branch
+
+`codex/stage4-closeout-and-handoff`
+
+## Goal
+
+Write an M4 review and closeout that explains what the local module changed,
+what improved, what did not improve, and what remains outside scope.
+
+## Tasks
+
+- summarize the implemented local module and its insertion point
+- summarize baseline vs local-module comparison results
+- state clearly which slices improved and which did not
+- record what remains blocked or out of scope
+- prepare the next handoff entry if more method work is needed
+
+## Resource Boundary
+
+- stay inside the engineering-line evidence actually produced
+- do not claim formal benchmark completion
+- do not infer unsupported conclusions from low-support slices
+
+## Non-Goals
+
+- no benchmark overclaim
+- no silent relabeling of engineering results as formal results
+- no unrelated roadmap rewrite
+
+## Deliverable
+
+- M4 review doc
+- M4 closeout or handoff doc, depending on result quality
+
+## Acceptance
+
+- the review is grounded in actual artifacts
+- the closeout states both improvements and remaining limitations
+- the final wording is safe for future handoff

--- a/docs/gitflow/milestones/m2_community_forensics_integration.md
+++ b/docs/gitflow/milestones/m2_community_forensics_integration.md
@@ -3,6 +3,12 @@
 GitHub milestone:
 - `https://github.com/re-tourist/AIGC-Detection/milestone/3`
 
+GitHub issues:
+- `#13` - https://github.com/re-tourist/AIGC-Detection/issues/13
+- `#14` - https://github.com/re-tourist/AIGC-Detection/issues/14
+- `#15` - https://github.com/re-tourist/AIGC-Detection/issues/15
+- `#16` - https://github.com/re-tourist/AIGC-Detection/issues/16
+
 ## Goal
 
 Integrate Community Forensics as a baseline candidate under the current repository contract.
@@ -69,6 +75,10 @@ The objective is integration, not paper reproduction.
 ## Issue Set
 
 - Issue 2.1 - Intake Community Forensics source and freeze adapter contract
+  - GitHub: https://github.com/re-tourist/AIGC-Detection/issues/13
 - Issue 2.2 - Implement prediction adapter and sample alignment
+  - GitHub: https://github.com/re-tourist/AIGC-Detection/issues/14
 - Issue 2.3 - Sanity-check adapter with BR-Gen rehearsal manifest
+  - GitHub: https://github.com/re-tourist/AIGC-Detection/issues/15
 - Issue 2.4 - Review and milestone closeout
+  - GitHub: https://github.com/re-tourist/AIGC-Detection/issues/16

--- a/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
+++ b/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
@@ -3,27 +3,138 @@
 GitHub milestone:
 - `https://github.com/re-tourist/AIGC-Detection/milestone/4`
 
+## Status
+
+- Local repo status:
+  - M3 code paths for formal BR-Gen manifest preparation, perturbation-aware
+    Community Forensics export, and localized-failure sidecar reporting are
+    implemented
+  - the expanded full-COCO restricted pilot has been executed on Linux and the
+    resulting failure-evidence artifacts are available in the workspace
+  - focused local tests pass in the current workspace
+- Remaining milestone status:
+  - formal M3 remains blocked because ImageNet / Places real negatives are
+    unavailable
+  - the executable and evidenced path is currently the expanded
+    `COCO-only restricted_pilot`
+- Current evidence level:
+  - restricted-pilot failure mapping exists
+  - formal benchmark evidence does not yet exist
+  - formal milestone closeout is not yet justified
+
 ## Goal
 
-在你的 localized eval protocol 下正式评测 strong baseline，
-回答它在大量 localized edit 测试样本上是否仍然存在结构性 localized failure。
+Formally validate whether a strong baseline still shows structured failure on
+localized edits under the current repository data, metric, and runner contract.
+
+Current execution note:
+
+- the expanded full-COCO restricted pilot is complete
+- formal M3 is still blocked
+- current M3 evidence is diagnostic and restricted-pilot scoped, not formal
+  benchmark evidence
 
 ## In Scope
 
-- baseline 的正式 localized eval
-- overall + slice 结果汇总
-- clean / degraded 对比
-- 结果报告与结论整理
+- audit the official BR-Gen raw layout from the Linux server root
+- prepare clean and degraded localized manifests without copying the full
+  dataset into the repository
+- reuse the existing Community Forensics export path to produce repo-compatible
+  prediction JSONL
+- run the existing minimal runner plus an M3 sidecar report
+- execute and analyze the expanded `COCO-only restricted_pilot`
+- write a Linux runbook that separates restricted-pilot evidence from the
+  blocked formal full run
 
 ## Out of Scope
 
-- baseline integration 本身
-- 新方法实现
-- 论文最终撰写与 submission packaging
+- any change to the frozen M1 contract
+- Community Forensics paper reproduction
+- generator-diverse retraining
+- heuristic inference of new slice metadata
+- treating `data/tmp/cf_smoke/` as benchmark evidence
+- treating restricted-pilot results as formal benchmark evidence
+- M4 or later method work
+
+## Execution Contract
+
+### Official BR-Gen root
+
+- formal M3 work must take an explicit external source root
+- the current official root is:
+  - `/media/ruanzhengsen/02EE2033DCBE79181/xyj/BRGen/BR-Gen`
+- M3 must not silently fall back to `data/BR-Gen`
+
+### Raw layout assumptions
+
+- fake images must be discovered under:
+  - `Forged/<generator>/<region>/<source>/<file>`
+- mask root may be either:
+  - `Mask`
+  - `Masked`
+- real root may be either:
+  - `Real`
+  - `RealImage`
+  - `real`
+- ambiguous roots, invalid fake layout, or missing fake/mask/real pairing are
+  hard errors
+
+### Manifest contract
+
+- `clean_manifest.jsonl` contains clean localized real and fake samples only
+- `formal_manifest.jsonl` contains the clean set plus fixed degraded variants:
+  - `jpeg`
+  - `resize`
+  - `blur`
+  - `crop`
+- raw manifest records do not carry `edit_area_ratio`
+- degraded variants are represented through explicit `meta.perturbation`
+
+### Perturbation contract
+
+- JPEG quality:
+  - `85`
+- resize scale:
+  - `0.90`
+- Gaussian blur sigma:
+  - `1.0`
+- crop mode:
+  - centered crop retaining `90%` image area
+- degraded images are generated on the fly during export and are not written
+  back as copied dataset assets
+
+### Reporting contract
+
+- the existing minimal runner remains the first artifact writer
+- M3 adds a sidecar localized-failure report that summarizes:
+  - overall clean localized metrics
+  - metrics by degradation
+  - metrics by `region_type`
+  - metrics by `edit_area_ratio` bins
+  - blocked `subtlety`
+  - clean-to-degraded deltas
+  - worst-slice ranking
+  - coverage audit and failure evidence map for restricted-pilot analysis
 
 ## Exit Criteria
 
-- localized eval 结果完整可回溯
-- overall 与 slice 结果都已输出
-- 对“strong baseline 是否仍然失败”有明确书面结论
-- 后续是否进入 local branch + consistency 有决策依据
+- the official BR-Gen layout can be audited and manifests can be written
+  reproducibly
+- Community Forensics export can emit repo-compatible predictions for both the
+  restricted pilot and, when unblocked, the formal manifest
+- the minimal runner and M3 sidecar report both produce traceable artifacts
+- restricted-pilot evidence clearly states:
+  - what it shows
+  - what remains blocked
+  - why it is not a formal benchmark claim
+- the formal closeout remains pending until full formal execution is actually
+  run
+
+## Issue Set
+
+- Issue 3.0 - Sync M3 GitHub milestone and issue set
+- Issue 3.1 - Freeze M3 contract and audit official BR-Gen raw layout
+- Issue 3.2 - Prepare formal BR-Gen manifests and perturbation-aware export
+- Issue 3.3 - Add localized-failure sidecar reporting on top of the current runner
+- Issue 3.4 - Execute formal Linux run and write milestone closeout
+- Issue 3.5 - Expand restricted pilot evidence and failure mapping

--- a/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
+++ b/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
@@ -2,6 +2,7 @@
 
 GitHub milestone:
 - `https://github.com/re-tourist/AIGC-Detection/milestone/4`
+- state: `CLOSED`
 
 ## Status
 
@@ -11,16 +12,19 @@ GitHub milestone:
     implemented
   - the expanded full-COCO restricted pilot has been executed on Linux and the
     resulting failure-evidence artifacts are available in the workspace
+  - an explicit M3 closeout and M4 handoff has been written
   - focused local tests pass in the current workspace
 - Remaining milestone status:
-  - formal M3 remains blocked because ImageNet / Places real negatives are
+  - the active executed path is the expanded `COCO-only restricted_pilot`
+  - formal M3 remains unavailable because ImageNet / Places real negatives are
     unavailable
-  - the executable and evidenced path is currently the expanded
-    `COCO-only restricted_pilot`
+  - formal M3 is not the active next step and is being explicitly deferred
 - Current evidence level:
   - restricted-pilot failure mapping exists
-  - formal benchmark evidence does not yet exist
-  - formal milestone closeout is not yet justified
+  - restricted-pilot evidence is sufficient for M4 method entry
+  - formal benchmark evidence does not exist
+  - the milestone is being closed with documented limitations, not as a formal
+    benchmark success
 
 ## Goal
 
@@ -30,9 +34,10 @@ localized edits under the current repository data, metric, and runner contract.
 Current execution note:
 
 - the expanded full-COCO restricted pilot is complete
-- formal M3 is still blocked
+- formal M3 is intentionally deferred
 - current M3 evidence is diagnostic and restricted-pilot scoped, not formal
   benchmark evidence
+- the practical handoff target is M4 on the COCO-only engineering line
 
 ## In Scope
 
@@ -45,6 +50,8 @@ Current execution note:
 - execute and analyze the expanded `COCO-only restricted_pilot`
 - write a Linux runbook that separates restricted-pilot evidence from the
   blocked formal full run
+- write a closeout that explicitly hands off to M4 on the COCO-only
+  engineering line
 
 ## Out of Scope
 
@@ -54,7 +61,7 @@ Current execution note:
 - heuristic inference of new slice metadata
 - treating `data/tmp/cf_smoke/` as benchmark evidence
 - treating restricted-pilot results as formal benchmark evidence
-- M4 or later method work
+- formal M3 continuation without restored negatives
 
 ## Execution Contract
 
@@ -127,8 +134,9 @@ Current execution note:
   - what it shows
   - what remains blocked
   - why it is not a formal benchmark claim
-- the formal closeout remains pending until full formal execution is actually
-  run
+- the milestone closeout explicitly states that M3 is being handed off through
+  the `COCO-only restricted_pilot` line
+- the formal path is either executed or explicitly deferred before leaving M3
 
 ## Issue Set
 
@@ -136,5 +144,5 @@ Current execution note:
 - #18 Issue 3.1 - Freeze M3 contract and audit official BR-Gen raw layout
 - #19 Issue 3.2 - Prepare formal BR-Gen manifests and perturbation-aware export
 - #20 Issue 3.3 - Add localized-failure sidecar reporting on top of the current runner
-- #21 Issue 3.4 - Execute formal Linux run and write milestone closeout
+- #21 Issue 3.4 - Formal Linux run and formal closeout path (deferred)
 - #22 Issue 3.5 - Expand restricted pilot evidence and failure mapping

--- a/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
+++ b/docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md
@@ -132,9 +132,9 @@ Current execution note:
 
 ## Issue Set
 
-- Issue 3.0 - Sync M3 GitHub milestone and issue set
-- Issue 3.1 - Freeze M3 contract and audit official BR-Gen raw layout
-- Issue 3.2 - Prepare formal BR-Gen manifests and perturbation-aware export
-- Issue 3.3 - Add localized-failure sidecar reporting on top of the current runner
-- Issue 3.4 - Execute formal Linux run and write milestone closeout
-- Issue 3.5 - Expand restricted pilot evidence and failure mapping
+- #17 Issue 3.0 - Sync M3 GitHub milestone and issue set
+- #18 Issue 3.1 - Freeze M3 contract and audit official BR-Gen raw layout
+- #19 Issue 3.2 - Prepare formal BR-Gen manifests and perturbation-aware export
+- #20 Issue 3.3 - Add localized-failure sidecar reporting on top of the current runner
+- #21 Issue 3.4 - Execute formal Linux run and write milestone closeout
+- #22 Issue 3.5 - Expand restricted pilot evidence and failure mapping

--- a/docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md
+++ b/docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md
@@ -1,0 +1,86 @@
+# M4: Community Forensics Local Module on COCO Engineering Line
+
+GitHub milestone:
+- `https://github.com/re-tourist/AIGC-Detection/milestone/5`
+
+## Status
+
+- Planned milestone
+- Entry condition is satisfied:
+  - expanded full-COCO restricted pilot from M3 has completed
+  - failure evidence map exists
+  - Community Forensics baseline is already wired into the repo contracts
+- Active engineering boundary:
+  - `evaluation_scope = restricted_pilot`
+  - `dataset scope = COCO-only`
+- Explicitly not active:
+  - formal M3 continuation
+  - ImageNet / Places negatives
+  - paper-ready benchmark claims
+
+## Goal
+
+Add a local module on top of the current Community Forensics baseline and test
+whether it improves the already identified weak localized slices on the
+COCO-only engineering line.
+
+Current execution note:
+
+- M4 is not a formal benchmark milestone
+- M4 is a method-engineering milestone guided by M3 failure evidence
+- the first comparison target is baseline vs baseline-plus-local-module under
+  the existing restricted-pilot runner and sidecar
+
+## In Scope
+
+- freeze the M4 scope and evaluation boundary before coding
+- decide the narrowest viable integration point for a local module in the
+  Community Forensics path
+- implement the local module without breaking the existing baseline export/eval
+  contract
+- run baseline vs local-module comparisons on the full-COCO restricted pilot
+- analyze improvements or regressions on:
+  - `region_type`
+  - `edit_area_ratio`
+  - degradation slices
+  - the known weak axes from M3
+- write a reviewable M4 handoff and closeout when the COCO engineering goal is
+  sufficiently answered
+
+## Out of Scope
+
+- any attempt to revive formal M3 benchmark claims
+- ImageNet / Places negatives
+- contract changes to M1/M2 metric semantics
+- retraining against broader generator-diverse data
+- benchmark packaging for paper submission
+
+## Entry Criteria
+
+- M3 closeout is written and explicitly says the project is moving to M4 on the
+  COCO-only engineering line
+- the restricted-pilot artifacts are available:
+  - `summary.json`
+  - `localized_failure_summary.json`
+  - `failure_evidence_map.md`
+- the weak slices are explicit enough to drive method design:
+  - `stuff`
+  - `small / medium` edit area
+
+## Exit Criteria
+
+- a local module is integrated into the Community Forensics path
+- the repo can run baseline and local-module variants under the same
+  restricted-pilot contract
+- comparison artifacts clearly show:
+  - where the new module helps
+  - where it does not help
+  - what remains inconclusive
+- the final write-up avoids any formal-benchmark overclaim
+
+## Issue Set
+
+- #23 Issue 4.1 - Freeze M4 scope and local-module interface on the COCO engineering line
+- #24 Issue 4.2 - Integrate a local module into the Community Forensics baseline path
+- #25 Issue 4.3 - Run COCO-only baseline-vs-local-module comparison and slice audit
+- #26 Issue 4.4 - Write M4 review, handoff, and closeout for the engineering line

--- a/docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md
+++ b/docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md
@@ -5,7 +5,7 @@ GitHub milestone:
 
 ## Status
 
-- Planned milestone
+- Closed milestone
 - Entry condition is satisfied:
   - expanded full-COCO restricted pilot from M3 has completed
   - failure evidence map exists
@@ -17,6 +17,9 @@ GitHub milestone:
   - formal M3 continuation
   - ImageNet / Places negatives
   - paper-ready benchmark claims
+- Formal closeout completed:
+  - GitHub milestone `#5` is closed
+  - GitHub issues `#23` - `#26` are closed
 
 ## Goal
 

--- a/docs/handoff/milestone_closeout_stage3_strong_baseline_localized_failure_validation.md
+++ b/docs/handoff/milestone_closeout_stage3_strong_baseline_localized_failure_validation.md
@@ -1,0 +1,293 @@
+# milestone_closeout
+
+## Milestone Info
+
+- Milestone ID: `m3_strong_baseline_localized_failure_validation`
+- Milestone name: `M3: Strong Baseline Localized Failure Validation`
+- Status:
+  - [ ] complete
+  - [x] partially complete
+  - [ ] blocked
+  - [x] handed off with risks
+- Date: `2026-03-31`
+- Related stage / branch:
+  - `codex/stage3-github-sync`
+  - `codex/stage4-coco-local-module-entry`
+- Related plan doc:
+  - `docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md`
+- Related issue doc:
+  - `docs/gitflow/issues/m3_strong_baseline_localized_failure_validation/README.md`
+
+---
+
+## 1. Executive Summary
+
+M3 原本要回答的是：在当前仓库冻结的数据、metric、runner contract 下，Community Forensics 这个 strong baseline 是否在 localized edits 上仍然存在结构化 failure。
+
+实际完成情况分成两条线：
+- formal benchmark 线没有完成，也不会作为当前主线继续推进
+- `COCO-only restricted_pilot` 线已经从早期窄 pilot 扩成了 full-COCO restricted pilot，并已经形成可信的 failure evidence map
+
+当前 milestone 已经足以支撑进入下一个 milestone，但支撑方式不是“formal M3 已成立”，而是“COCO-only engineering line 已经有足够清晰的 weak-slice 证据，可以用来驱动 local module 设计”。
+
+最大的剩余问题不是代码缺口，而是边界问题：
+- formal M3 仍未建立
+- `subtlety` 仍 blocked
+- 当前所有方法证据都必须按 restricted-pilot 口径解释
+
+---
+
+## 2. What Was Completed
+
+- [x] formal/restricted pilot manifest pipeline 已实现
+  - 对应代码/文档位置：
+    - `src/aigc_detection/data/br_gen_formal.py`
+    - `scripts/prepare_br_gen_m3_formal.py`
+    - `docs/contracts/contract_freeze_stage3_strong_baseline_localized_failure_validation.md`
+  - 如何验证：
+    - focused tests 已通过
+    - Linux 上 restricted pilot manifest 已成功生成
+  - 是否已经达到预期：
+    - 对 restricted-pilot 路径，达到预期
+
+- [x] Community Forensics baseline 已接通 repo-compatible export/eval path
+  - 对应代码/文档位置：
+    - `scripts/export_community_forensics_predictions.py`
+    - `scripts/run_m3_formal_eval.py`
+    - `src/aigc_detection/eval/m3_runner.py`
+  - 如何验证：
+    - Linux 上 full-COCO restricted pilot export + eval 已跑通
+  - 是否已经达到预期：
+    - 达到 restricted-pilot 工程线预期
+
+- [x] localized sidecar 已扩展为 failure evidence map
+  - 对应代码/文档位置：
+    - `outputs/m3/restricted_pilot/eval/localized_failure_summary.json`
+    - `outputs/m3/restricted_pilot/eval/localized_coverage_summary.json`
+    - `outputs/m3/restricted_pilot/eval/coverage_audit.md`
+    - `outputs/m3/restricted_pilot/eval/failure_evidence_map.md`
+  - 如何验证：
+    - expanded full-COCO restricted pilot 已产出完整 artifacts
+  - 是否已经达到预期：
+    - 达到 M3 restricted-pilot 诊断目标
+
+- [x] expanded full-COCO restricted pilot 已执行完成
+  - 对应代码/文档位置：
+    - `data/mirrored/br_gen/subsets/restricted_pilot/manifest/layout_audit.json`
+    - `outputs/m3/restricted_pilot/eval/summary.json`
+    - `docs/review/review_stage3_restricted_pilot_coco_audit.md`
+  - 如何验证：
+    - `candidate_fake_pairs_before_cap = 50000`
+    - `selected_fake_pairs_after_cap = 50000`
+    - `fake_sample_cap_applied = false`
+    - eval rows = `275000`
+  - 是否已经达到预期：
+    - 已达到 “full COCO restricted pilot” 的执行预期
+
+---
+
+## 3. What Was Not Completed
+
+- [ ] formal M3 benchmark 没有完成
+  - 为什么没完成：
+    - ImageNet / Places negatives 仍然不可用
+  - 是 scope 调整、时间原因、依赖缺失，还是结果不支持继续：
+    - 外部数据依赖缺失 + 当前主线决策调整
+  - 是否应该进入下一个 milestone：
+    - 否。M4 不再追这条线
+
+- [ ] `subtlety` 维度没有解锁
+  - 为什么没完成：
+    - 当前 manifest / metadata 中没有 subtlety 字段
+  - 是 scope 调整、时间原因、依赖缺失，还是结果不支持继续：
+    - metadata blocked
+  - 是否应该进入下一个 milestone：
+    - 否，除非数据侧先补齐
+
+- [ ] formal benchmark claim 不能建立
+  - 为什么没完成：
+    - 当前结果只有 restricted-pilot 口径
+  - 是 scope 调整、时间原因、依赖缺失，还是结果不支持继续：
+    - contract 边界决定
+  - 是否应该进入下一个 milestone：
+    - 否。M4 先做工程线比较
+
+---
+
+## 4. Key Files and Changes
+
+### Code
+
+- `src/aigc_detection/data/br_gen_formal.py`
+  - 作用：
+    - 生成 formal/restricted pilot manifests
+  - 在本 milestone 中承担什么责任：
+    - 让 COCO-only restricted pilot 可执行
+
+- `src/aigc_detection/eval/m3_runner.py`
+  - 作用：
+    - 产出 localized coverage 和 failure evidence artifacts
+  - 在本 milestone 中承担什么责任：
+    - 将 M3 从 overall-score 检查推进到 slice-level diagnosis
+
+- `scripts/export_community_forensics_predictions.py`
+  - 作用：
+    - 导出 repo-compatible predictions
+  - 在本 milestone 中承担什么责任：
+    - 承载 Community Forensics baseline 的 restricted-pilot 推理
+
+### Docs
+
+- `docs/review/review_stage3_restricted_pilot_coco_audit.md`
+  - 作用：
+    - 审计 expanded full-COCO restricted pilot 结果
+  - 是否已与实现同步：
+    - 是
+
+- `docs/analysis/m3_restricted_pilot_success_criteria.md`
+  - 作用：
+    - 定义 restricted pilot 成功标准
+  - 是否已与实现同步：
+    - 是
+
+- `docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md`
+  - 作用：
+    - 记录 M3 当前状态与边界
+  - 是否已与实现同步：
+    - 本次 closeout 后已同步成 handoff 状态
+
+### Config / Scripts / Assets
+
+- `data/mirrored/br_gen/subsets/restricted_pilot/manifest/`
+  - 作用：
+    - 保存 full-COCO restricted pilot manifests 与 layout audit
+  - 当前是否可直接复用：
+    - 可以，M4 继续沿用
+
+- `outputs/m3/restricted_pilot/eval/`
+  - 作用：
+    - 保存 restricted pilot 的 eval / coverage / failure artifacts
+  - 当前是否可直接复用：
+    - 可以，M4 直接用作 baseline evidence
+
+---
+
+## 5. Validation Summary
+
+### Validation Run
+
+- focused local tests：
+  - `python -m unittest discover -s tests -p 'test_*.py' -v`
+- Linux restricted pilot manifest/export/eval：
+  - 已完成
+- expanded full-COCO restricted pilot artifact audit：
+  - 已完成
+
+### What These Checks Actually Prove
+
+- 证明了什么：
+  - 当前 repo 能完整执行 Community Forensics 的 COCO-only restricted pilot
+  - current sidecar 已足够输出 failure map
+  - `stuff` 与 `small / medium area` 是当前最可信的 weak slices
+- 没证明什么：
+  - formal benchmark
+  - ImageNet / Places negatives 下的表现
+  - subtlety 维度的 failure
+
+### Missing or Weak Validation
+
+- formal BR-Gen full benchmark 没有执行
+- 当前没有 formal closeout 所需的跨源 negatives 验证
+
+---
+
+## 6. Risks and Known Limitations
+
+### P0 / blocking
+
+- formal 线当前已被主动递延
+  - 风险出现在哪里：
+    - 任何未来写作若误把 restricted pilot 当 formal benchmark，会直接越界
+  - 会影响什么：
+    - benchmark 表述与 milestone 定性
+  - 是否会误导下一个 milestone：
+    - 会，所以必须在 handoff 里写死
+
+### P1 / serious but not blocking
+
+- 当前所有方法证据都来自 `COCO-only restricted_pilot`
+  - 会影响什么：
+    - 不能直接外推成 formal benchmark claim
+
+- `subtlety` 仍然 blocked
+  - 会影响什么：
+    - 无法把 failure 分析推进到更细的隐蔽性层级
+
+### P2 / should improve later
+
+- 当前结果解释仍需同时看 ranking 和 fixed-threshold behavior
+- future M4 如果只看 overall score，容易错过真正的 slice-level 改善或退化
+
+---
+
+## 7. Contract / Scope Notes
+
+- [x] 完全在冻结 contract 内执行
+- [ ] 有小范围偏离，但已说明
+- [ ] 出现了 contract 级别问题
+- [x] 发生了实际 scope 漂移
+- [ ] 没有正式 contract freeze
+
+补充说明：
+- M3 的原标题是 formal localized failure validation
+- 实际收口是 restricted-pilot engineering handoff
+- 这次 scope 调整是显式决策，不是偷偷缩窄
+- formal 线被明确递延，不得在 M4 中被误写成“已经完成”
+
+---
+
+## 8. Recommended Next Entry Point
+
+### Recommended first task
+
+- 在 Community Forensics baseline 之上接入一个 local module，并在现有 full-COCO restricted pilot 上做 baseline vs local-module 对比
+
+### Recommended first files to read
+
+- `docs/gitflow/milestones/m4_community_forensics_local_module_coco_engineering_line.md`
+- `docs/handoff/milestone_closeout_stage3_strong_baseline_localized_failure_validation.md`
+- `docs/review/review_stage3_restricted_pilot_coco_audit.md`
+- `outputs/m3/restricted_pilot/eval/failure_evidence_map.md`
+
+### Recommended first checks
+
+- 确认 M4 仍然严格停留在 `COCO-only restricted_pilot`
+- 先看 `stuff` 和 `small / medium area` 这两条 failure axes
+- 确认新模块接入后仍然复用现有 prediction/eval/sidecar contract
+
+### Recommended decision to make before coding
+
+- local module 的最小集成点放在 Community Forensics 的哪一层
+- M4 的成功判据是“slice 改善是否真实”，而不是“overall 看起来更高”
+
+---
+
+## 9. Handoff Guidance
+
+- 不要再为 formal M3 补做工程线之外的收尾。
+- 不要把 restricted pilot 结果包装成论文 benchmark。
+- M4 的入口不是“重跑 M3”，而是“复用 M3 结果，针对已知 weak slices 做 engineering comparison”。
+- 任何新模块都必须先在 `stuff` 和 `small / medium area` 上回答是否有改善。
+- `subtlety` 缺失不是 bug，是已知 metadata 限制。
+
+---
+
+## 10. Final Verdict
+
+- [ ] milestone can be cleanly closed
+- [x] milestone can be closed with documented limitations
+- [ ] milestone should remain open pending one last validation
+- [ ] milestone should not be closed because the result is not yet reliable
+
+最后一句总结：
+- 当前结论：M3 可以作为一个“restricted-pilot-only, COCO-only engineering handoff”关闭；formal benchmark 问题仍未解决，但这已经不再阻止进入 M4。

--- a/docs/handoff/milestone_closeout_stage4_local_module_restricted_pilot.md
+++ b/docs/handoff/milestone_closeout_stage4_local_module_restricted_pilot.md
@@ -1,0 +1,123 @@
+# M4 Local Module Restricted Pilot Closeout
+
+## Milestone Info
+
+- Milestone: `M4 Local Evidence Module on the COCO Restricted Pilot`
+- Status: `closed with limitations`
+- Evaluation scope: `restricted_pilot`
+- Dataset scope: `COCO-only`
+
+## 1. What M4 Completed
+
+- Added a minimal local evidence probe on top of the verified CF-ViT path.
+- Kept the baseline forward path intact when the probe is disabled.
+- Ran a fair baseline-vs-local-module restricted-pilot comparison.
+- Verified that the probe changes behavior without breaking the easy regime.
+
+## 2. What M4 Did Not Complete
+
+- It did not prove the local probe is the final method.
+- It did not train a new model.
+- It did not change the frozen M1/M2 eval substrate.
+- It did not produce a formal benchmark claim.
+
+## 3. What the Results Say
+
+The run is credible and slice-aligned:
+- same manifest
+- same sample order
+- same eval scope
+- same support regime
+- only local probe activation differs
+
+Measured effect:
+- overall metrics improved slightly
+- `background` remained easy and improved
+- `stuff` improved modestly
+- `small` and `medium` improved only marginally and remain weak
+
+Interpretation:
+- the local probe is not inert
+- the current hard top-k formulation is too weak to claim a decisive fix
+- the result is useful diagnostic evidence, not method validation
+
+## 4. Why This Is Still Not a Benchmark Claim
+
+The evidence comes from a restricted-pilot engineering line.
+That line is explicitly diagnostic.
+
+It does not have:
+- formal benchmark negatives
+- formal M3 closure
+- a claim of cross-dataset generality
+- a claim that the local module is the final architecture
+
+## 5. Decision
+
+M4 is closed with limitations.
+
+The project should not jump straight into M5 as if the current probe already
+proved the method.
+The better reading is:
+- the local line is viable
+- it produced a positive but weak signal
+- more diagnostics would be required before a training-stage commitment
+
+## 6. Next Stage Recommendation
+
+Do not start M5 immediately.
+If M5 is ever opened, it should be because the project wants to test whether
+trainable local scoring and soft aggregation can amplify the weak positive
+signal observed here.
+
+That decision should be made as a new milestone, not as an automatic extension
+of this one.
+
+## 7. Multi-Seed Audit Addendum
+
+After the original single-run closeout, an M4 multi-seed stability audit was
+attempted in this workspace.
+
+Actual outcome:
+- run id: `m4_multi_seed_20260402T133603Z_unknown`
+- requested seeds: `0,1,2,3,4`
+- successful seeds: `0`
+- failed seeds: `5`
+- the audit never reached model inference on any seed
+
+Root cause:
+- the local data mirror is missing a forged BR-Gen image referenced by the
+  manifest
+- the first reported missing file was
+  `D:\home\workspace\AIGC\data\BRGen\BR-Gen\Forged\BrushNet\Background\COCO\000000000772_background.png`
+- the corresponding mask file is present, which confirms this is a forged-image
+  availability gap rather than a general directory mismatch
+
+Implication:
+- the multi-seed stability question remains unresolved in this workspace
+- this does not overturn the single-run closeout
+- it does mean we should not overstate seed-stability until the full forged-image
+  mirror is available and the audit is rerun
+
+## 8. Multi-Seed Stability Closeout
+
+The later Linux rerun completed successfully and supersedes the earlier blocked
+workspace attempt for the purpose of the final M4 judgment.
+
+Final run facts:
+- run id: `m4_multi_seed_20260403T024452Z_unknown`
+- successful seeds: `5/5`
+- failed seeds: `0/5`
+
+Final reading:
+- the no-train local probe is seed-stable on the blind-spot slices
+- `stuff`, `small`, and `medium` all improve in the same direction across all
+  five seeds
+- `background` stays easy and improves
+- `overall_auroc` is weakly positive, but not the main signal
+
+Closeout statement:
+- `M4 = capability complete + seed-stability audited diagnostic evidence`
+- M4 remains a restricted-pilot diagnostic milestone, not a benchmark claim
+- M5 is now justified only as a new milestone if the project wants to test
+  trainable amplification of the same local-evidence signal

--- a/docs/handoff/prompt_next_thread_stage4_context.md
+++ b/docs/handoff/prompt_next_thread_stage4_context.md
@@ -1,0 +1,60 @@
+# Stage4 Next-Thread Context Prompt
+
+下面这段 prompt 只提供上下文和边界，不替代你自己的正式 M4 实现提示词。
+
+```text
+请在仓库 `D:\MyProject\AIGC-Detection` 中继续工作。
+
+先对齐当前真实状态，不要回头重开 M3：
+
+1. M3 已经正式收口，但收口方式是：
+   - `COCO-only restricted_pilot` 工程线已完成
+   - formal M3 benchmark 没有完成，且当前不再继续推进
+   - M3 的结论只能按 restricted-pilot diagnostic evidence 来使用
+   - 不要把 M3 写成 formal benchmark success
+
+2. 当前 M3 的关键结论：
+   - expanded full-COCO restricted pilot 已完成
+   - `stuff` 是稳定 weak slice
+   - `small / medium` edit area 是稳定 weak slice
+   - `background` 仍然是 easy regime
+   - `subtlety` 仍 blocked
+
+3. 当前应视为 source-of-truth 的文件：
+   - `docs/handoff/milestone_closeout_stage3_strong_baseline_localized_failure_validation.md`
+   - `docs/review/review_stage3_restricted_pilot_coco_audit.md`
+   - `docs/gitflow/milestones/m3_strong_baseline_localized_failure_validation.md`
+   - `outputs/m3/restricted_pilot/eval/failure_evidence_map.md`
+   - `outputs/m3/restricted_pilot/eval/localized_failure_summary.json`
+   - `outputs/m3/restricted_pilot/eval/summary.json`
+   - `data/mirrored/br_gen/subsets/restricted_pilot/manifest/layout_audit.json`
+
+4. GitHub 当前状态：
+   - M3 milestone 已关闭：`milestone/4`
+   - M3 issues `#17-#22` 已全部关闭
+   - M4 milestone 已创建：`milestone/5`
+   - M4 issues 已创建并保持 open：
+     - `#23`
+     - `#24`
+     - `#25`
+     - `#26`
+
+5. 进入新工作前必须遵守：
+   - 不要重新打开 formal M3 线路
+   - 不要引入 ImageNet / Places negatives
+   - 不要把 restricted-pilot 结果包装成 benchmark claim
+   - 不要改动现有 M1/M2 metric contract
+   - 优先复用现有 Community Forensics baseline export / eval / sidecar 路径
+
+6. 当前本地工作区不是干净的：
+   - 存在与本任务无关的未提交和未跟踪文件
+   - 不要回滚或混入无关改动
+   - 只在你自己的 scope 内增量修改
+
+7. 当前起始分支与提交：
+   - branch: `codex/stage4-coco-local-module-entry`
+   - commit: `adc4797`
+
+你接下来具体怎么做，以我后续补充的正式 M4 提示词为准。
+在开始实现前，先读取上述文档并复述你理解到的边界，再进入具体工作。
+```

--- a/docs/handoff/prompt_next_thread_stage4_context.md
+++ b/docs/handoff/prompt_next_thread_stage4_context.md
@@ -53,7 +53,7 @@
 
 7. 当前起始分支与提交：
    - branch: `codex/stage4-coco-local-module-entry`
-   - commit: `a17c860`
+   - current head 请在开始前用 `git rev-parse --short HEAD` 自查，不要硬编码旧提交号
 
 你接下来具体怎么做，以我后续补充的正式 M4 提示词为准。
 在开始实现前，先读取上述文档并复述你理解到的边界，再进入具体工作。

--- a/docs/handoff/prompt_next_thread_stage4_context.md
+++ b/docs/handoff/prompt_next_thread_stage4_context.md
@@ -53,7 +53,7 @@
 
 7. 当前起始分支与提交：
    - branch: `codex/stage4-coco-local-module-entry`
-   - commit: `adc4797`
+   - commit: `a17c860`
 
 你接下来具体怎么做，以我后续补充的正式 M4 提示词为准。
 在开始实现前，先读取上述文档并复述你理解到的边界，再进入具体工作。

--- a/docs/plan/m4_multi_seed_audit.md
+++ b/docs/plan/m4_multi_seed_audit.md
@@ -1,0 +1,103 @@
+# M4 Multi-Seed Stability Audit Plan
+
+## Goal
+
+Audit whether the observed no-train local-probe gain on the COCO-only
+restricted pilot is stable across random initializations, rather than a lucky
+single seed.
+
+This audit is still M4.
+It is not M5, not training, and not a benchmark expansion.
+
+## Boundary
+
+- keep `models/local_module.py` unchanged
+- keep `models/local_wrapper.py` unchanged
+- keep the hard top-k no-train probe
+- keep the restricted-pilot eval substrate unchanged
+- reuse the existing baseline restricted-pilot result as the control
+- do not modify the metric contract or introduce training
+
+## Run Shape
+
+- baseline: reuse `outputs/m4/restricted_pilot/eval_baseline`
+- local probe: run 5 seeds by default, 3 minimum if compute is tight
+- output root: `outputs/m4/multi_seed_audit/<run_id>/`
+- each seed gets its own subdirectory:
+  - `seed_000/`
+  - `seed_001/`
+  - ...
+
+## Command
+
+```bash
+python scripts/run_m4_multi_seed_audit.py --seeds 0,1,2,3,4 --device cuda --batch-size 16 --progress-every 100
+```
+
+If compute is limited, pass a shorter seed list:
+
+```bash
+python scripts/run_m4_multi_seed_audit.py --seeds 0,1,2 --device cuda --batch-size 16 --progress-every 100
+```
+
+## Outputs
+
+Per seed:
+
+- `predictions_local_module.jsonl`
+- `eval/summary.json`
+- `eval/localized_failure_summary.json`
+- `eval/localized_coverage_summary.json`
+- `export.log`
+- `eval.log`
+- `metadata.json`
+- `export_command.json`
+- `eval_command.json`
+
+Top level:
+
+- `summary.json`
+- `manifest.json`
+- `aggregate_metrics.json`
+- `aggregate_metrics.md`
+- `run_status.md`
+
+## Success Criteria
+
+- multi-seed audit completes without overwriting previous runs
+- baseline reuse is recorded explicitly
+- each seed has isolated output and logs
+- aggregate stats are generated for overall and slice-level metrics
+- the result can be judged as seed-stable, weakly positive, or unstable
+
+## Failure Criteria
+
+- seed outputs collide or overwrite each other
+- baseline and seed runs are not comparable
+- the audit silently drops failed seeds
+- the output only reports a single run without aggregation
+- the run drifts into training or a new method definition
+
+## Execution Note
+
+The runner is wired correctly, but the current workspace does not contain the
+full forged-image mirror required to complete the audit.
+
+Observed blocker:
+- the first missing asset reported by the manifest loader was
+  `D:\home\workspace\AIGC\data\BRGen\BR-Gen\Forged\BrushNet\Background\COCO\000000000772_background.png`
+- all seeds failed before inference because of that missing forged image
+
+This means the audit is structurally implemented, but seed-stability evidence is
+still unavailable in this workspace until the forged-image mirror is complete.
+
+## Repository Workflow Note
+
+- Full restricted-pilot audits and training-scale runs are expected to execute
+  on Linux servers with the complete BR-Gen forged-image mirror.
+- Local workspace validation is limited to code paths, CLI behavior, config
+  parsing, and unit tests.
+- When adding a new experiment or rerun, record the exact command in
+  `docs/run_order.md` with a timestamped heading and a short note describing the
+  purpose, environment, and output root. Preserve prior entries instead of
+  overwriting them.

--- a/docs/review/review_stage4_local_module_restricted_pilot.md
+++ b/docs/review/review_stage4_local_module_restricted_pilot.md
@@ -1,0 +1,218 @@
+# M4 Local Module Restricted Pilot Review
+
+## Inputs
+
+- `outputs/m4/restricted_pilot/predictions_baseline.jsonl`
+- `outputs/m4/restricted_pilot/predictions_local_module.jsonl`
+- `outputs/m4/restricted_pilot/eval_baseline/summary.json`
+- `outputs/m4/restricted_pilot/eval_local_module/summary.json`
+- `outputs/m4/restricted_pilot/eval_baseline/localized_failure_summary.json`
+- `outputs/m4/restricted_pilot/eval_local_module/localized_failure_summary.json`
+- `outputs/m4/restricted_pilot/eval_baseline/localized_coverage_summary.json`
+- `outputs/m4/restricted_pilot/eval_local_module/localized_coverage_summary.json`
+
+## 1. 结果可信度审计
+
+This comparison is credible.
+
+Reasons:
+- Both prediction files contain `275000` rows.
+- `sample_id` ordering is identical across baseline and local-module outputs.
+- Both eval runs use the same manifest and the same `restricted_pilot` scope.
+- Coverage is identical on the dimensions that matter for this milestone:
+  - `region_type`
+  - `edit_area_ratio`
+  - `degradation`
+  - `generator_id`
+- `subtlety` remains blocked in both runs, which matches the frozen M4 contract.
+- The local-module prediction metadata only adds `meta.local_module`; it does
+  not change manifest coverage or sample selection.
+
+Result status:
+- trusted enough for milestone judgment
+- not a benchmark claim
+- not sufficient for a formal method conclusion
+
+## 2. baseline vs local-module 核心对比
+
+Overall numbers move up slightly:
+- Accuracy: `0.5384181818181818 -> 0.5507272727272727`
+- AUROC: `0.8754560336 -> 0.8773497972`
+- fake_recall: `0.4924 -> 0.505992`
+
+Slice-level readout:
+- `background` improves and remains easy.
+- `stuff` improves modestly.
+- `small` improves from essentially zero to still essentially zero.
+- `medium` improves slightly but remains very weak.
+
+This is a real behavioral shift, but a small one.
+
+## 3. Slice Interpretation
+
+### `background`
+
+This remains the easy regime.
+The probe does not break it, and it improves slightly.
+That is a positive stability signal.
+
+### `stuff`
+
+This is still the clearest weak slice.
+The local probe nudges fake_recall upward by about `+0.0106`, but the slice
+remains far below the clean reference.
+This is a positive signal, but not strong enough to call the slice fixed.
+
+### `small`
+
+This remains effectively blocked.
+The change from `0.0` to `0.0008988764044943821` is measurable but tiny.
+This does not support a claim that the current hard probe solves small-area
+blind spots.
+
+### `medium`
+
+This is the most useful positive movement after `stuff`, but it is still weak.
+The gain is only `+0.0035` fake_recall.
+That suggests local evidence is present, but the current hard top-k aggregation
+is not extracting it strongly.
+
+## 4. Pattern Classification
+
+The result is best classified as:
+
+- **B. 有变化但不稳定**
+
+Why not A:
+- The probe does change the decision surface.
+- The change is visible in overall and slice-level numbers.
+
+Why not C:
+- The improvement is modest.
+- The weak slices are still weak.
+- The signal is not concentrated enough to justify a stronger claim.
+
+Why not D:
+- The baseline is not destroyed.
+- The easy regime remains easy.
+- There is no sign that the insertion point is structurally broken.
+
+## 5. M4 Close Decision
+
+My judgment:
+- **M4 can close**
+- but only as a capability / probe milestone
+- and only with documented limitations
+
+Reason:
+- The probe behaves as intended.
+- The comparison is credible.
+- The result is useful diagnostically.
+- It is enough to stop M4 from being open-ended.
+
+## 6. M5 Decision
+
+My judgment:
+- **do not enter M5 immediately**
+
+Reason:
+- The signal is positive, but weak.
+- The probe did not sharply recover the known blind spots.
+- The evidence is not strong enough to justify a training-stage commitment yet.
+
+What would have supported M5 more strongly:
+- a clearer lift on `stuff`
+- a clearer lift on `small` / `medium`
+- or a stronger sign that hard top-k is the bottleneck, not the local line
+  itself
+
+## 7. Verdict
+
+**Verdict 2: M4 可以 close，但不建议立刻进 M5，先补更多诊断。**
+
+Grounding:
+- close, because the probe works and the evidence is credible
+- not M5 yet, because the effect size is too small and too broad to justify the
+  next training step
+
+## 8. Remaining Risks
+
+- The gain may not survive a different local-module parameter choice.
+- The hard top-k formulation may still be too rigid.
+- The current probe is only one narrow insertion point, so it may understate
+  what a trainable local scoring path could recover.
+
+## 9. Recommendation
+
+Close M4 with limitations documented.
+Do not promote the current result to a formal benchmark claim.
+If the project later revisits M5, use this run as diagnostic motivation rather
+than as proof of method success.
+
+## 10. Multi-Seed Stability Audit
+
+An M4 multi-seed audit was launched in this workspace through
+`scripts/run_m4_multi_seed_audit.py`.
+
+Observed result:
+- run id: `m4_multi_seed_20260402T133603Z_unknown`
+- requested seeds: `0,1,2,3,4`
+- successful seeds: `0`
+- failed seeds: `5`
+- all five seeds failed before inference completed
+
+Failure cause:
+- the manifest loader hit a missing forged image file in the local data mirror
+- the first reported missing asset was
+  `D:\home\workspace\AIGC\data\BRGen\BR-Gen\Forged\BrushNet\Background\COCO\000000000772_background.png`
+- the corresponding mask file exists locally, but the forged image file does not
+
+Interpretation:
+- this blocks any seed-stability conclusion in the current workspace
+- there is no basis to call the single-run gain a lucky seed or a stable effect
+  from the multi-seed audit, because the multi-seed audit never reached model
+  inference
+- the only usable M4 behavioral evidence remains the single-run restricted-pilot
+  comparison
+
+## 11. Multi-Seed Stability Audit Update
+
+The blocked workspace attempt above is historical. The final Linux rerun
+completed successfully and is the basis for the current stability judgment.
+
+Run facts:
+- run id: `m4_multi_seed_20260403T024452Z_unknown`
+- seeds: `0,1,2,3,4`
+- successful seeds: `5/5`
+- failed seeds: `0/5`
+
+Slice-level summary:
+- `background`: stable improvement, easy regime preserved
+- `stuff`: stable improvement across all seeds
+- `small`: measurable but still effectively blocked
+- `medium`: stable but weak improvement
+- `large`: positive sanity check
+- `subtlety`: blocked in all five seeds
+
+Aggregate interpretation:
+- `stuff`, `small`, and `medium` all improve in the same direction across all
+  five seeds
+- the blind-spot signal is therefore structural, not a lucky seed
+- `overall_auroc` is only weakly positive and is not the main evidence for this
+  milestone
+
+Updated pattern classification:
+- **A. Stable positive**
+
+Updated verdict:
+- M4 can close as capability complete + seed-stability audited diagnostic
+  evidence
+- the current no-train probe is worth keeping as diagnostic evidence
+- M5 is now justified as a separate milestone if the project wants to test
+  trainable amplification of the same local-evidence signal
+
+Updated reading:
+- current verdict on M4 itself does not change
+- current seed-stability audit status is blocked by data completeness
+- if the full forged-image mirror becomes available later, the multi-seed audit
+  should be rerun before revisiting any stronger stability claim

--- a/docs/run_order.md
+++ b/docs/run_order.md
@@ -1,31 +1,20 @@
-# M3 Run Order
+# Run Order Index
 
-# 这次先确认容器里的 Python 版本，Community-Forensics baseline 建议使用 Python 3.10 或 3.11，不要继续在旧的 3.8 环境里硬跑。
-python -c "import sys; print(sys.version)"
+根文件只保留索引。新增命令请写到 `docs/run_order/` 下对应的 phase 文档。
 
-# 这次先在容器内仓库根目录安装根级依赖，requirements.txt 已包含 Community-Forensics baseline 所需依赖。
-pip install -r requirements.txt
+## Active Docs
 
-# 下面所有命令都假定你已经进入容器内仓库根目录 /home/workspace/AIGC，并且宿主机 BRGen 已挂载到容器内 data/BRGen。
-pwd && ls data/BRGen && ls data/BRGen/BR-Gen && ls data/BRGen/BR-Gen/RealImage/COCO
+- [Run Order README](run_order/README.md)
+- [M5b Seed Ladder](run_order/m5b_seed_ladder.md)
+- [M5b Recovery Smoke](run_order/m5b_recovery_smoke.md)
+- [M5b Canary Rerun](run_order/m5b_canary_rerun.md)
+- [M5b Validation Smoke](run_order/m5b_validation_smoke.md)
 
-# 这次先在容器内仓库根目录跑测试，确认 restricted pilot 代码状态正常。
-python -m unittest discover -s tests -p 'test_*.py' -v
+## Supporting Docs
 
-# 这次先 dry-run 解析 COCO image list，只验证路径、文件名和 audit schema，不下载文件。
-python scripts/materialize_br_gen_real_subset.py --source-root data/BRGen/BR-Gen --source-dataset COCO --output-root data/BRGen/BR-Gen/RealImage --dry-run
+- [M5b Resume / State Contract](contracts/m5b_resume_and_state_contract.md)
+- [M5b Troubleshooting](troubleshooting.md)
 
-# 这次正式 materialize BR-Gen 实际引用的 COCO real 子集，只下载 image_list 里列出的文件，不下载整套 COCO，并打开进度输出和单请求超时。
-python scripts/materialize_br_gen_real_subset.py --source-root data/BRGen/BR-Gen --source-dataset COCO --output-root data/BRGen/BR-Gen/RealImage --timeout-seconds 20 --progress-every 10
+## Legacy Note
 
-# 这次生成 expanded COCO-only restricted pilot manifest，不再使用 64 fake 样本 cap，只保留 source_id=COCO，并保持 evaluation_scope=restricted_pilot。
-python scripts/prepare_br_gen_m3_formal.py --source-root data/BRGen/BR-Gen --output-root data/mirrored/br_gen/subsets/restricted_pilot --allowed-sources COCO
-
-# 这次对 expanded restricted pilot manifest 跑 Community Forensics baseline，导出 repo-compatible prediction JSONL。
-python scripts/export_community_forensics_predictions.py --manifest data/mirrored/br_gen/subsets/restricted_pilot/manifest/formal_manifest.jsonl --output outputs/m3/restricted_pilot/predictions.jsonl --device cuda --batch-size 16
-
-# 这次对 expanded restricted pilot predictions 跑 minimal runner 和增强后的 localized sidecar，结果只用于 coverage audit 与 failure discovery，不作为 formal benchmark。
-python scripts/run_m3_formal_eval.py --manifest data/mirrored/br_gen/subsets/restricted_pilot/manifest/formal_manifest.jsonl --predictions outputs/m3/restricted_pilot/predictions.jsonl --output-dir outputs/m3/restricted_pilot/eval
-
-# 这次最后检查 expanded restricted pilot 关键产物是否齐全，包括 summary、localized summary、coverage audit、failure evidence map 和 localized coverage summary。
-ls data/mirrored/br_gen/subsets/restricted_pilot/manifest && ls outputs/m3/restricted_pilot/eval
+旧的单文件命令历史已经从根文件移出。需要回看历史时，请看 git history 或逐步迁移到新的 phase 文档。

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from .local_module import LocalEvidenceModule, LocalEvidenceModuleError
+from .local_wrapper import (
+    LocalModuleConfig,
+    LocalModuleConfigError,
+    ViTClassifier,
+    load_local_module_config,
+)
+from .m5_wrapper import (
+    M5LocalModuleConfig,
+    M5LocalModuleConfigError,
+    M5ViTClassifier,
+    TrainableLocalAggregationViTClassifier,
+    load_m5_local_module_config,
+)
+from .trainable_local_module import (
+    TrainableLocalAggregationConfig,
+    TrainableLocalAggregationError,
+    TrainableLocalAggregationModule,
+)
+
+__all__ = [
+    "LocalEvidenceModule",
+    "LocalEvidenceModuleError",
+    "LocalModuleConfig",
+    "LocalModuleConfigError",
+    "M5LocalModuleConfig",
+    "M5LocalModuleConfigError",
+    "M5ViTClassifier",
+    "TrainableLocalAggregationConfig",
+    "TrainableLocalAggregationError",
+    "TrainableLocalAggregationModule",
+    "TrainableLocalAggregationViTClassifier",
+    "ViTClassifier",
+    "load_local_module_config",
+    "load_m5_local_module_config",
+]

--- a/models/local_module.py
+++ b/models/local_module.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import torch
+from torch import Tensor, nn
+
+
+class LocalEvidenceModuleError(ValueError):
+    """Raised when the local evidence probe receives invalid token input."""
+
+
+class LocalEvidenceModule(nn.Module):
+    """Top-k local evidence probe over patch tokens."""
+
+    def __init__(
+        self,
+        token_dim: int,
+        *,
+        k: int = 16,
+        module_type: str = "topk",
+    ) -> None:
+        super().__init__()
+        if isinstance(token_dim, bool) or not isinstance(token_dim, int) or token_dim <= 0:
+            raise LocalEvidenceModuleError(
+                f"token_dim must be a positive integer, got {token_dim!r}"
+            )
+
+        module_type = str(module_type).strip().lower()
+        if module_type != "topk":
+            raise LocalEvidenceModuleError(f"Unsupported local module type: {module_type!r}")
+
+        if isinstance(k, bool) or not isinstance(k, int) or k <= 0:
+            raise LocalEvidenceModuleError(f"k must be a positive integer, got {k!r}")
+
+        self.token_dim = int(token_dim)
+        self.k = int(k)
+        self.module_type = module_type
+        hidden_dim = max(self.token_dim, 1)
+        self.score_mlp = nn.Sequential(
+            nn.Linear(self.token_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, patch_tokens: Tensor) -> Tensor:
+        if patch_tokens.ndim != 3:
+            raise LocalEvidenceModuleError(
+                f"patch_tokens must have shape [B, N, D], got {tuple(patch_tokens.shape)}"
+            )
+        if patch_tokens.size(1) == 0:
+            raise LocalEvidenceModuleError("patch_tokens must contain at least one token")
+        if patch_tokens.size(-1) != self.token_dim:
+            raise LocalEvidenceModuleError(
+                f"Expected token dimension {self.token_dim}, got {patch_tokens.size(-1)}"
+            )
+
+        scores = self.score_mlp(patch_tokens)
+        if scores.ndim != 3 or scores.size(0) != patch_tokens.size(0) or scores.size(1) != patch_tokens.size(1) or scores.size(-1) != 1:
+            raise LocalEvidenceModuleError(
+                f"score_mlp must return shape [B, N, 1], got {tuple(scores.shape)}"
+            )
+
+        scores = scores.squeeze(-1)
+        top_k = min(self.k, patch_tokens.size(1))
+        selected_indices = torch.topk(scores, k=top_k, dim=1).indices
+        expanded_indices = selected_indices.unsqueeze(-1).expand(-1, -1, patch_tokens.size(-1))
+        selected_tokens = torch.gather(patch_tokens, dim=1, index=expanded_indices)
+        return selected_tokens.mean(dim=1)

--- a/models/local_wrapper.py
+++ b/models/local_wrapper.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Mapping
+
+import torch
+from torch import Tensor, nn
+import yaml
+
+from .local_module import LocalEvidenceModule
+
+
+class LocalModuleConfigError(ValueError):
+    """Raised when the local module config file is malformed."""
+
+
+@dataclass(frozen=True)
+class LocalModuleConfig:
+    module_type: str = "topk"
+    k: int = 16
+
+
+class ViTClassifier(nn.Module):
+    """Community Forensics ViT wrapper with an optional local evidence probe."""
+
+    def __init__(
+        self,
+        *,
+        base_model: nn.Module,
+        use_local_module: bool = False,
+        local_module_config: LocalModuleConfig | Mapping[str, Any] | None = None,
+        model_size: str | None = None,
+        input_size: int | None = None,
+        patch_size: int | None = None,
+        freeze_backbone: bool | None = None,
+        device: str | torch.device | None = None,
+        dtype: torch.dtype | None = None,
+    ) -> None:
+        super().__init__()
+        self.base_model = base_model
+        self.use_local_module = bool(use_local_module)
+        self.model_size = model_size
+        self.input_size = input_size
+        self.patch_size = patch_size
+        self.freeze_backbone = freeze_backbone
+        self.device = device
+        self.dtype = dtype
+        self.local_module_config = (
+            _normalize_local_module_config(local_module_config) if self.use_local_module else LocalModuleConfig()
+        )
+
+        self.local_module: LocalEvidenceModule | None = None
+        if self.use_local_module:
+            self.local_module = LocalEvidenceModule(
+                token_dim=self._embed_dim,
+                k=self.local_module_config.k,
+                module_type=self.local_module_config.module_type,
+            )
+
+    @property
+    def vit(self) -> nn.Module:
+        vit = getattr(self.base_model, "vit", None)
+        if vit is None:
+            raise LocalModuleConfigError("Base model does not expose a ViT backbone")
+        return vit
+
+    @property
+    def _embed_dim(self) -> int:
+        head = getattr(self.vit, "head", None)
+        if head is None:
+            raise LocalModuleConfigError("Base model ViT does not expose a classification head")
+        in_features = getattr(head, "in_features", None)
+        if not isinstance(in_features, int):
+            raise LocalModuleConfigError("Base model head does not expose an integer in_features")
+        return in_features
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_model_name_or_path: str | Path,
+        *,
+        model_size: str = "small",
+        input_size: int = 384,
+        patch_size: int = 16,
+        freeze_backbone: bool = False,
+        device: str | torch.device = "cpu",
+        dtype: torch.dtype = torch.float32,
+        use_local_module: bool = False,
+        local_module_config: LocalModuleConfig | Mapping[str, Any] | None = None,
+    ) -> "ViTClassifier":
+        baseline_cls = _load_external_vit_classifier_class()
+        base_model = baseline_cls.from_pretrained(
+            pretrained_model_name_or_path,
+            model_size=model_size,
+            input_size=input_size,
+            patch_size=patch_size,
+            freeze_backbone=freeze_backbone,
+            device=device,
+            dtype=dtype,
+        )
+
+        normalized_local_config = (
+            _normalize_local_module_config(local_module_config) if use_local_module else None
+        )
+        wrapper = cls(
+            base_model=base_model,
+            use_local_module=use_local_module,
+            local_module_config=normalized_local_config,
+            model_size=model_size,
+            input_size=input_size,
+            patch_size=patch_size,
+            freeze_backbone=freeze_backbone,
+            device=device,
+            dtype=dtype,
+        )
+        return wrapper.to(device)
+
+    def forward(self, x: Tensor) -> Tensor:
+        if not self.use_local_module or self.local_module is None:
+            return self.base_model(x)
+
+        tokens = self.vit.forward_features(x)
+        if tokens.ndim != 3 or tokens.size(1) < 2:
+            raise LocalModuleConfigError(
+                f"Expected backbone token output with shape [B, 1+N, D], got {tuple(tokens.shape)}"
+            )
+
+        f_global = tokens[:, 0, :]
+        patch_tokens = tokens[:, 1:, :]
+        f_local = self.local_module(patch_tokens)
+        f_out = f_global + f_local
+        return self.vit.head(f_out)
+
+
+def load_local_module_config(config_path: str | Path) -> LocalModuleConfig:
+    path = Path(config_path).expanduser().resolve()
+    if not path.exists():
+        raise LocalModuleConfigError(f"Local module config does not exist: {path}")
+    if path.suffix.lower() not in {".yaml", ".yml"}:
+        raise LocalModuleConfigError(f"Local module config must be YAML, got: {path.name}")
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise LocalModuleConfigError("Local module config must be a mapping at the document root")
+
+    unknown_top_level = sorted(set(raw) - {"model"})
+    if unknown_top_level:
+        raise LocalModuleConfigError(
+            f"Unknown top-level keys in local module config: {', '.join(unknown_top_level)}"
+        )
+
+    model_cfg = raw.get("model")
+    if not isinstance(model_cfg, dict):
+        raise LocalModuleConfigError("Local module config must contain a 'model' mapping")
+    if "use_local_module" in model_cfg:
+        raise LocalModuleConfigError(
+            "Activation must be controlled by the CLI flag only; remove model.use_local_module from YAML"
+        )
+
+    unknown_model_keys = sorted(set(model_cfg) - {"local_module"})
+    if unknown_model_keys:
+        raise LocalModuleConfigError(
+            f"Unknown keys in model mapping: {', '.join(unknown_model_keys)}"
+        )
+
+    local_cfg = model_cfg.get("local_module")
+    if not isinstance(local_cfg, dict):
+        raise LocalModuleConfigError("Local module config must contain model.local_module")
+
+    unknown_local_keys = sorted(set(local_cfg) - {"type", "k"})
+    if unknown_local_keys:
+        raise LocalModuleConfigError(
+            f"Unknown keys in model.local_module: {', '.join(unknown_local_keys)}"
+        )
+
+    module_type = local_cfg.get("type")
+    if not isinstance(module_type, str) or not module_type.strip():
+        raise LocalModuleConfigError("model.local_module.type must be a non-empty string")
+    module_type = module_type.strip().lower()
+    if module_type != "topk":
+        raise LocalModuleConfigError(f"Unsupported local module type: {module_type!r}")
+
+    k = local_cfg.get("k")
+    if isinstance(k, bool) or not isinstance(k, int):
+        raise LocalModuleConfigError("model.local_module.k must be an integer")
+    if k <= 0:
+        raise LocalModuleConfigError("model.local_module.k must be positive")
+
+    return LocalModuleConfig(module_type=module_type, k=k)
+
+
+def _normalize_local_module_config(
+    local_module_config: LocalModuleConfig | Mapping[str, Any] | None,
+) -> LocalModuleConfig:
+    if local_module_config is None:
+        return LocalModuleConfig()
+    if isinstance(local_module_config, LocalModuleConfig):
+        return local_module_config
+    if isinstance(local_module_config, Mapping):
+        unknown_keys = sorted(set(local_module_config) - {"type", "module_type", "k"})
+        if unknown_keys:
+            raise LocalModuleConfigError(
+                f"Unknown keys in local module config: {', '.join(unknown_keys)}"
+            )
+        module_type = local_module_config.get(
+            "type", local_module_config.get("module_type", "topk")
+        )
+        k = local_module_config.get("k", 16)
+        if not isinstance(module_type, str) or not module_type.strip():
+            raise LocalModuleConfigError("local module type must be a non-empty string")
+        module_type = module_type.strip().lower()
+        if module_type != "topk":
+            raise LocalModuleConfigError(f"Unsupported local module type: {module_type!r}")
+        if isinstance(k, bool) or not isinstance(k, int):
+            raise LocalModuleConfigError("local module k must be an integer")
+        if k <= 0:
+            raise LocalModuleConfigError("local module k must be positive")
+        return LocalModuleConfig(module_type=module_type, k=k)
+    raise LocalModuleConfigError(
+        f"Unsupported local module config type: {type(local_module_config).__name__}"
+    )
+
+
+@lru_cache(maxsize=1)
+def _load_external_vit_classifier_class() -> type[nn.Module]:
+    repo_root = Path(__file__).resolve().parents[1]
+    external_models_path = repo_root / "external" / "Community-Forensics" / "models.py"
+    if not external_models_path.exists():
+        raise ModuleNotFoundError(
+            f"Expected Community Forensics models at {external_models_path}"
+        )
+
+    module_name = "_community_forensics_external_models"
+    spec = importlib.util.spec_from_file_location(module_name, external_models_path)
+    if spec is None or spec.loader is None:
+        raise ModuleNotFoundError(
+            f"Could not load Community Forensics models from {external_models_path}"
+        )
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    try:
+        return module.ViTClassifier
+    except AttributeError as error:
+        raise ModuleNotFoundError(
+            f"Community Forensics models file does not export ViTClassifier: {external_models_path}"
+        ) from error

--- a/scripts/export_community_forensics_predictions.py
+++ b/scripts/export_community_forensics_predictions.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import contextmanager
 import json
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import torch
 from PIL import Image
@@ -15,10 +17,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 EXTERNAL_ROOT = REPO_ROOT / "external" / "Community-Forensics"
 
-if str(SRC_ROOT) not in sys.path:
-    sys.path.insert(0, str(SRC_ROOT))
 if str(EXTERNAL_ROOT) not in sys.path:
     sys.path.insert(0, str(EXTERNAL_ROOT))
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from aigc_detection.data.manifest import load_manifest
 from aigc_detection.eval.perturbations import apply_manifest_perturbation, get_manifest_perturbation
@@ -30,6 +34,23 @@ class ExportArtifacts:
     manifest_path: Path
     sample_count: int
     device: str
+
+
+@contextmanager
+def _seeded_torch_rng(seed: int | None):
+    if seed is None:
+        yield
+        return
+
+    cpu_state = torch.random.get_rng_state()
+    cuda_state = torch.cuda.get_rng_state_all() if torch.cuda.is_available() else None
+    try:
+        torch.manual_seed(seed)
+        yield
+    finally:
+        torch.random.set_rng_state(cpu_state)
+        if cuda_state is not None:
+            torch.cuda.set_rng_state_all(cuda_state)
 
 
 class ManifestImageDataset(Dataset):
@@ -77,12 +98,28 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument("--num-workers", type=int, default=0)
     parser.add_argument(
+        "--use-local-module",
+        action="store_true",
+        help="Enable the inference-time local evidence probe.",
+    )
+    parser.add_argument(
+        "--local-module-config",
+        default=str(REPO_ROOT / "configs" / "model" / "local_module.yaml"),
+        help="YAML file containing model.local_module parameters.",
+    )
+    parser.add_argument(
         "--device",
         default="auto",
         choices=("auto", "cpu", "cuda"),
         help="Inference device. Auto prefers CUDA when available.",
     )
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--progress-every",
+        type=int,
+        default=0,
+        help="Emit progress every N batches while exporting. 0 disables progress logs.",
+    )
     return parser
 
 
@@ -107,19 +144,28 @@ def main() -> int:
         pin_memory=(device == "cuda"),
     )
 
-    model = _load_model(
-        hf_model_repo=args.hf_model_repo,
-        model_size=args.model_size,
-        input_size=args.input_size,
-        patch_size=args.patch_size,
-        device=device,
+    local_module_config = _load_local_module_config_if_enabled(
+        enabled=args.use_local_module,
+        config_path=args.local_module_config,
     )
+    with _seeded_torch_rng(args.seed if args.use_local_module else None):
+        model = _load_model(
+            hf_model_repo=args.hf_model_repo,
+            model_size=args.model_size,
+            input_size=args.input_size,
+            patch_size=args.patch_size,
+            device=device,
+            use_local_module=args.use_local_module,
+            local_module_config=local_module_config,
+        )
+    local_module_metadata = _describe_local_module_config(local_module_config)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     records_written = 0
+    total_batches = len(dataloader)
     with torch.inference_mode():
         with output_path.open("w", encoding="utf-8") as handle:
-            for batch in dataloader:
+            for batch_index, batch in enumerate(dataloader, start=1):
                 (
                     inputs,
                     sample_ids,
@@ -164,6 +210,8 @@ def main() -> int:
                             "score_semantics": "higher_is_more_likely_fake_probability",
                         },
                     }
+                    if args.use_local_module:
+                        record["meta"]["local_module"] = local_module_metadata
                     sample_meta = sample_meta_by_id.get(sample_id)
                     if isinstance(sample_meta, dict) and sample_meta.get("evaluation_scope"):
                         record["meta"]["evaluation_scope"] = sample_meta["evaluation_scope"]
@@ -171,6 +219,15 @@ def main() -> int:
                         record["meta"]["perturbation"] = json.loads(perturbation_json)
                     handle.write(json.dumps(record, ensure_ascii=False) + "\n")
                     records_written += 1
+
+                if args.progress_every > 0 and (
+                    batch_index % args.progress_every == 0 or batch_index == total_batches
+                ):
+                    print(
+                        f"Export progress: batch {batch_index}/{total_batches}, "
+                        f"records={records_written}/{len(dataset)}",
+                        flush=True,
+                    )
 
     print(f"Manifest: {manifest_path}")
     print(f"Output: {output_path}")
@@ -206,6 +263,8 @@ def _load_model(
     input_size: int,
     patch_size: int,
     device: str,
+    use_local_module: bool = False,
+    local_module_config: Any | None = None,
 ):
     try:
         from models import ViTClassifier
@@ -227,6 +286,8 @@ def _load_model(
             freeze_backbone=False,
             device=device,
             dtype=torch.float32,
+            use_local_module=use_local_module,
+            local_module_config=local_module_config,
         ).to(device)
         model.eval()
         return model
@@ -242,9 +303,33 @@ def _load_model(
             freeze_backbone=False,
             device=fallback_device,
             dtype=torch.float32,
+            use_local_module=use_local_module,
+            local_module_config=local_module_config,
         ).to(fallback_device)
         model.eval()
         return model
+
+
+def _load_local_module_config_if_enabled(*, enabled: bool, config_path: str):
+    if not enabled:
+        return None
+    from models import load_local_module_config
+
+    return load_local_module_config(config_path)
+
+
+def _describe_local_module_config(local_module_config: Any) -> dict[str, Any]:
+    if local_module_config is None:
+        return {}
+    module_type = getattr(local_module_config, "module_type", None)
+    k = getattr(local_module_config, "k", None)
+    if module_type is None and isinstance(local_module_config, dict):
+        module_type = local_module_config.get("type", local_module_config.get("module_type"))
+        k = local_module_config.get("k")
+    return {
+        "type": module_type,
+        "k": k,
+    }
 
 
 if __name__ == "__main__":

--- a/scripts/run_m4_multi_seed_audit.py
+++ b/scripts/run_m4_multi_seed_audit.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from aigc_detection.eval.m4_audit import (  # noqa: E402
+    aggregate_seed_audit,
+    load_reference_artifacts,
+    load_seed_metrics,
+    render_aggregate_markdown,
+    render_run_status_markdown,
+)
+
+
+DEFAULT_MANIFEST = (
+    REPO_ROOT
+    / "data"
+    / "mirrored"
+    / "br_gen"
+    / "subsets"
+    / "restricted_pilot"
+    / "manifest"
+    / "formal_manifest.jsonl"
+)
+DEFAULT_BASELINE_EVAL_DIR = REPO_ROOT / "outputs" / "m4" / "restricted_pilot" / "eval_baseline"
+DEFAULT_BASELINE_PREDICTIONS = (
+    REPO_ROOT / "outputs" / "m4" / "restricted_pilot" / "predictions_baseline.jsonl"
+)
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "outputs" / "m4" / "multi_seed_audit"
+DEFAULT_LOCAL_MODULE_CONFIG = REPO_ROOT / "configs" / "model" / "local_module.yaml"
+DEFAULT_HF_MODEL_REPO = (
+    REPO_ROOT / "external" / "Community-Forensics" / "weights" / "commfor-model-384"
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run the M4 multi-seed stability audit for the no-train local probe."
+    )
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--baseline-eval-dir", default=str(DEFAULT_BASELINE_EVAL_DIR))
+    parser.add_argument("--baseline-predictions", default=str(DEFAULT_BASELINE_PREDICTIONS))
+    parser.add_argument("--output-root", default=str(DEFAULT_OUTPUT_ROOT))
+    parser.add_argument("--hf-model-repo", default=str(DEFAULT_HF_MODEL_REPO))
+    parser.add_argument("--model-size", default="small", choices=("small", "tiny"))
+    parser.add_argument("--input-size", type=int, default=384, choices=(224, 384))
+    parser.add_argument("--patch-size", type=int, default=16, choices=(16, 32))
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--device", default="auto", choices=("auto", "cpu", "cuda"))
+    parser.add_argument("--threshold", type=float, default=0.5)
+    parser.add_argument("--seeds", default="0,1,2,3,4")
+    parser.add_argument("--progress-every", type=int, default=100)
+    parser.add_argument("--local-module-config", default=str(DEFAULT_LOCAL_MODULE_CONFIG))
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest_path = Path(args.manifest).resolve()
+    baseline_eval_dir = Path(args.baseline_eval_dir).resolve()
+    baseline_predictions_path = Path(args.baseline_predictions).resolve()
+    output_root = Path(args.output_root).resolve()
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    reference = load_reference_artifacts(baseline_eval_dir)
+    _validate_reference(reference, manifest_path)
+
+    seeds = _parse_seeds(args.seeds)
+    run_id = _make_run_id(output_root)
+    run_dir = output_root / run_id
+    run_dir.mkdir(parents=False, exist_ok=False)
+
+    print(
+        f"[M4 multi-seed] run_id={run_id} | baseline_reuse=yes | seeds={len(seeds)} | output={run_dir}",
+        flush=True,
+    )
+    print(f"[M4 multi-seed] manifest={manifest_path}", flush=True)
+    print(f"[M4 multi-seed] baseline eval dir={baseline_eval_dir}", flush=True)
+    print(f"[M4 multi-seed] baseline predictions={baseline_predictions_path}", flush=True)
+
+    started_at = datetime.now(timezone.utc)
+    seed_runs: list[dict[str, Any]] = []
+
+    for index, seed in enumerate(seeds, start=1):
+        seed_dir = run_dir / f"seed_{index - 1:03d}"
+        seed_dir.mkdir(parents=False, exist_ok=False)
+        print(
+            f"[M4 multi-seed] seed {index}/{len(seeds)} -> {seed} | output={seed_dir}",
+            flush=True,
+        )
+        seed_record = _run_single_seed(
+            seed=seed,
+            seed_index=index - 1,
+            total_seeds=len(seeds),
+            seed_dir=seed_dir,
+            manifest_path=manifest_path,
+            args=args,
+        )
+        seed_runs.append(seed_record)
+        current_summary = {
+            "run_id": run_id,
+            "scope": reference.get("evaluation_scope"),
+            "manifest_path": str(manifest_path),
+            "output_root": str(output_root),
+            "seed_runs": seed_runs,
+            "status": _status_from_seed_runs(seed_runs),
+        }
+        _write_text(run_dir / "run_status.md", render_run_status_markdown(current_summary))
+
+    completed_at = datetime.now(timezone.utc)
+    aggregate_error: str | None = None
+    try:
+        summary = aggregate_seed_audit(
+            run_id=run_id,
+            manifest_path=manifest_path,
+            output_root=output_root,
+            reference=reference,
+            seed_runs=seed_runs,
+            baseline_eval_dir=baseline_eval_dir,
+            baseline_predictions_path=baseline_predictions_path,
+        )
+    except ValueError as error:
+        aggregate_error = str(error)
+        summary = {
+            "run_id": run_id,
+            "scope": reference.get("evaluation_scope"),
+            "manifest_path": str(manifest_path),
+            "output_root": str(output_root),
+            "baseline": {
+                "eval_dir": str(baseline_eval_dir),
+                "predictions_path": str(baseline_predictions_path),
+                "reference": reference,
+            },
+            "seed_runs": seed_runs,
+            "status": _status_from_seed_runs(seed_runs),
+            "aggregate": {
+                "numeric_metrics": {},
+                "subtlety": {
+                    "baseline": reference["subtlety"]["status"],
+                    "local_statuses": [],
+                    "local_status_counts": {},
+                    "all_same": False,
+                },
+                "error": aggregate_error,
+            },
+        }
+    summary["started_at_utc"] = started_at.isoformat().replace("+00:00", "Z")
+    summary["completed_at_utc"] = completed_at.isoformat().replace("+00:00", "Z")
+    summary["requested_seeds"] = seeds
+    summary["baseline_reference"] = reference
+
+    _write_json(run_dir / "summary.json", summary)
+    _write_json(
+        run_dir / "manifest.json",
+        _build_manifest_payload(
+            summary=summary,
+            args=args,
+            manifest_path=manifest_path,
+            baseline_eval_dir=baseline_eval_dir,
+            baseline_predictions_path=baseline_predictions_path,
+        ),
+    )
+    _write_json(run_dir / "aggregate_metrics.json", summary["aggregate"])
+    if summary["aggregate"]["numeric_metrics"]:
+        _write_text(run_dir / "aggregate_metrics.md", render_aggregate_markdown(summary))
+    else:
+        _write_text(
+            run_dir / "aggregate_metrics.md",
+            "\n".join(
+                [
+                    "# M4 Multi-Seed Local Probe Audit",
+                    "",
+                    f"- Run ID: `{summary['run_id']}`",
+                    f"- Scope: `{summary.get('scope')}`",
+                    f"- Manifest: `{summary['manifest_path']}`",
+                    f"- Output root: `{summary['output_root']}`",
+                    f"- Successful seeds: `{summary['status']['successful_seeds']}` / `{summary['status']['total_seeds']}`",
+                    f"- Failed seeds: `{summary['status']['failed_seeds']}`",
+                    "",
+                    "No successful seeds were available for aggregation.",
+                    f"Aggregate error: `{summary['aggregate']['error']}`",
+                    "",
+                ]
+            ),
+        )
+    _write_text(run_dir / "run_status.md", render_run_status_markdown(summary))
+
+    print(f"[M4 multi-seed] aggregate metrics: {run_dir / 'aggregate_metrics.json'}", flush=True)
+    print(f"[M4 multi-seed] aggregate markdown: {run_dir / 'aggregate_metrics.md'}", flush=True)
+    print(f"[M4 multi-seed] run status: {run_dir / 'run_status.md'}", flush=True)
+    print(
+        f"[M4 multi-seed] success={summary['status']['successful_seeds']} | failure={summary['status']['failed_seeds']}",
+        flush=True,
+    )
+    return 0 if summary["status"]["successful_seeds"] > 0 else 1
+
+
+def _run_single_seed(
+    *,
+    seed: int,
+    seed_index: int,
+    total_seeds: int,
+    seed_dir: Path,
+    manifest_path: Path,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    started_at = datetime.now(timezone.utc)
+    stage_status = {"export": "pending", "eval": "pending"}
+    stage_durations: dict[str, float] = {}
+
+    export_output = seed_dir / "predictions_local_module.jsonl"
+    eval_dir = seed_dir / "eval"
+    export_log = seed_dir / "export.log"
+    eval_log = seed_dir / "eval.log"
+
+    export_command = [
+        sys.executable,
+        "-u",
+        str(REPO_ROOT / "scripts" / "export_community_forensics_predictions.py"),
+        "--manifest",
+        str(manifest_path),
+        "--output",
+        str(export_output),
+        "--device",
+        args.device,
+        "--batch-size",
+        str(args.batch_size),
+        "--num-workers",
+        str(args.num_workers),
+        "--use-local-module",
+        "--local-module-config",
+        str(Path(args.local_module_config).resolve()),
+        "--seed",
+        str(seed),
+        "--progress-every",
+        str(args.progress_every),
+        "--hf-model-repo",
+        args.hf_model_repo,
+        "--model-size",
+        args.model_size,
+        "--input-size",
+        str(args.input_size),
+        "--patch-size",
+        str(args.patch_size),
+    ]
+    eval_command = [
+        sys.executable,
+        "-u",
+        str(REPO_ROOT / "scripts" / "run_m3_formal_eval.py"),
+        "--manifest",
+        str(manifest_path),
+        "--predictions",
+        str(export_output),
+        "--output-dir",
+        str(eval_dir),
+        "--threshold",
+        str(args.threshold),
+    ]
+
+    _write_json(seed_dir / "export_command.json", {"argv": export_command, "display": _format_command(export_command)})
+    _write_json(seed_dir / "eval_command.json", {"argv": eval_command, "display": _format_command(eval_command)})
+
+    export_started = time.perf_counter()
+    export_error: str | None = None
+    try:
+        _run_command(export_command, log_path=export_log, cwd=REPO_ROOT, prefix=f"seed {seed:03d} export")
+        stage_status["export"] = "success"
+    except subprocess.CalledProcessError:
+        stage_status["export"] = "failed"
+        export_error = _read_tail(export_log)
+    stage_durations["export"] = time.perf_counter() - export_started
+    if stage_status["export"] != "success":
+        finished_at = datetime.now(timezone.utc)
+        metadata = _build_metadata(
+            seed=seed,
+            seed_index=seed_index,
+            total_seeds=total_seeds,
+            started_at=started_at,
+            finished_at=finished_at,
+            stage_status=stage_status,
+            stage_durations=stage_durations,
+            export_output=export_output,
+            eval_dir=eval_dir,
+            export_command=export_command,
+            eval_command=eval_command,
+            export_log=export_log,
+            eval_log=eval_log,
+            error=export_error,
+            manifest_path=manifest_path,
+        )
+        _write_json(seed_dir / "metadata.json", metadata)
+        return _seed_record(
+            seed=seed,
+            seed_index=seed_index,
+            seed_dir=seed_dir,
+            started_at=started_at,
+            finished_at=finished_at,
+            stage_status=stage_status,
+            stage_durations=stage_durations,
+            export_output=export_output,
+            eval_dir=eval_dir,
+            export_command=export_command,
+            eval_command=eval_command,
+            export_log=export_log,
+            eval_log=eval_log,
+            status="failed",
+            error=export_error,
+        )
+
+    eval_started = time.perf_counter()
+    eval_error: str | None = None
+    try:
+        _run_command(eval_command, log_path=eval_log, cwd=REPO_ROOT, prefix=f"seed {seed:03d} eval")
+        stage_status["eval"] = "success"
+    except subprocess.CalledProcessError:
+        stage_status["eval"] = "failed"
+        eval_error = _read_tail(eval_log)
+    stage_durations["eval"] = time.perf_counter() - eval_started
+
+    metrics = None
+    status = "failed"
+    error = export_error or eval_error
+    if stage_status["export"] == "success" and stage_status["eval"] == "success":
+        try:
+            metrics = load_seed_metrics(eval_dir)
+            status = "success"
+        except Exception as artifact_error:  # pragma: no cover - defensive path for corrupted artifacts
+            status = "failed"
+            stage_status["eval"] = "failed"
+            error = str(artifact_error)
+            eval_error = error
+            metrics = None
+            status = "failed"
+    finished_at = datetime.now(timezone.utc)
+    metadata = _build_metadata(
+        seed=seed,
+        seed_index=seed_index,
+        total_seeds=total_seeds,
+        started_at=started_at,
+        finished_at=finished_at,
+        stage_status=stage_status,
+        stage_durations=stage_durations,
+        export_output=export_output,
+        eval_dir=eval_dir,
+        export_command=export_command,
+        eval_command=eval_command,
+        export_log=export_log,
+        eval_log=eval_log,
+        error=error if status != "success" else None,
+        manifest_path=manifest_path,
+    )
+    _write_json(seed_dir / "metadata.json", metadata)
+    return _seed_record(
+        seed=seed,
+        seed_index=seed_index,
+        seed_dir=seed_dir,
+        started_at=started_at,
+        finished_at=finished_at,
+        stage_status=stage_status,
+        stage_durations=stage_durations,
+        export_output=export_output,
+        eval_dir=eval_dir,
+        export_command=export_command,
+        eval_command=eval_command,
+        export_log=export_log,
+        eval_log=eval_log,
+        status=status,
+        error=error,
+        metrics=metrics,
+    )
+
+
+def _seed_record(
+    *,
+    seed: int,
+    seed_index: int,
+    seed_dir: Path,
+    started_at: datetime,
+    finished_at: datetime,
+    stage_status: dict[str, str],
+    stage_durations: dict[str, float],
+    export_output: Path,
+    eval_dir: Path,
+    export_command: Sequence[str],
+    eval_command: Sequence[str],
+    export_log: Path,
+    eval_log: Path,
+    status: str,
+    error: str | None,
+    metrics: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "seed": seed,
+        "seed_index": seed_index,
+        "seed_dir": str(seed_dir),
+        "status": status,
+        "stages": dict(stage_status),
+        "stage_durations_seconds": dict(stage_durations),
+        "duration_seconds": (finished_at - started_at).total_seconds(),
+        "started_at_utc": started_at.isoformat().replace("+00:00", "Z"),
+        "finished_at_utc": finished_at.isoformat().replace("+00:00", "Z"),
+        "output_dir": str(seed_dir),
+        "export_output": str(export_output),
+        "eval_dir": str(eval_dir),
+        "export_log": str(export_log),
+        "eval_log": str(eval_log),
+        "export_command": _format_command(export_command),
+        "eval_command": _format_command(eval_command),
+        "metrics": metrics,
+        "error": error,
+    }
+
+
+def _build_metadata(
+    *,
+    seed: int,
+    seed_index: int,
+    total_seeds: int,
+    started_at: datetime,
+    finished_at: datetime,
+    stage_status: dict[str, str],
+    stage_durations: dict[str, float],
+    export_output: Path,
+    eval_dir: Path,
+    export_command: Sequence[str],
+    eval_command: Sequence[str],
+    export_log: Path,
+    eval_log: Path,
+    error: str | None,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    return {
+        "seed": seed,
+        "seed_index": seed_index,
+        "total_seeds": total_seeds,
+        "status": "failed" if error else "success",
+        "stages": dict(stage_status),
+        "stage_durations_seconds": dict(stage_durations),
+        "started_at_utc": started_at.isoformat().replace("+00:00", "Z"),
+        "finished_at_utc": finished_at.isoformat().replace("+00:00", "Z"),
+        "duration_seconds": (finished_at - started_at).total_seconds(),
+        "git_commit": _git_commit(short=False),
+        "manifest_path": str(manifest_path),
+        "export": {
+            "output_path": str(export_output),
+            "command": list(export_command),
+            "command_display": _format_command(export_command),
+            "log_path": str(export_log),
+        },
+        "eval": {
+            "output_dir": str(eval_dir),
+            "command": list(eval_command),
+            "command_display": _format_command(eval_command),
+            "log_path": str(eval_log),
+        },
+        "error": error,
+    }
+
+
+def _build_manifest_payload(
+    *,
+    summary: dict[str, Any],
+    args: argparse.Namespace,
+    manifest_path: Path,
+    baseline_eval_dir: Path,
+    baseline_predictions_path: Path,
+) -> dict[str, Any]:
+    return {
+        "run_id": summary["run_id"],
+        "scope": summary.get("scope"),
+        "manifest_path": str(manifest_path),
+        "baseline_eval_dir": str(baseline_eval_dir),
+        "baseline_predictions_path": str(baseline_predictions_path),
+        "output_root": summary["output_root"],
+        "requested_seeds": summary.get("requested_seeds", []),
+        "command": {
+            "device": args.device,
+            "model_size": args.model_size,
+            "input_size": args.input_size,
+            "patch_size": args.patch_size,
+            "batch_size": args.batch_size,
+            "num_workers": args.num_workers,
+            "threshold": args.threshold,
+            "hf_model_repo": args.hf_model_repo,
+            "local_module_config": str(Path(args.local_module_config).resolve()),
+            "progress_every": args.progress_every,
+        },
+    }
+
+
+def _validate_reference(reference: dict[str, Any], manifest_path: Path) -> None:
+    if reference.get("evaluation_scope") != "restricted_pilot":
+        raise ValueError(
+            f"Baseline reference scope must be restricted_pilot, got {reference.get('evaluation_scope')!r}"
+        )
+    if reference.get("sample_count") is None:
+        raise ValueError("Baseline reference is missing sample_count")
+    if not Path(reference["summary_path"]).exists():
+        raise ValueError(f"Baseline summary missing: {reference['summary_path']}")
+    if not Path(reference["localized_summary_path"]).exists():
+        raise ValueError(f"Baseline localized summary missing: {reference['localized_summary_path']}")
+    if not manifest_path.exists():
+        raise ValueError(f"Manifest does not exist: {manifest_path}")
+
+
+def _status_from_seed_runs(seed_runs: list[dict[str, Any]]) -> dict[str, Any]:
+    successful = [run for run in seed_runs if run["status"] == "success"]
+    failed = [run for run in seed_runs if run["status"] != "success"]
+    return {
+        "total_seeds": len(seed_runs),
+        "successful_seeds": len(successful),
+        "failed_seeds": len(failed),
+        "failed_seed_ids": [run["seed"] for run in failed],
+    }
+
+
+def _run_command(
+    command: Sequence[str],
+    *,
+    log_path: Path,
+    cwd: Path,
+    prefix: str,
+) -> None:
+    env = os.environ.copy()
+    env["PYTHONUNBUFFERED"] = "1"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("w", encoding="utf-8") as log_handle:
+        process = subprocess.Popen(
+            list(command),
+            cwd=str(cwd),
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            log_handle.write(line)
+            log_handle.flush()
+            print(f"[{prefix}] {line.rstrip()}", flush=True)
+        returncode = process.wait()
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, list(command))
+
+
+def _make_run_id(output_root: Path) -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    sha = _git_commit(short=True)
+    base = f"m4_multi_seed_{timestamp}_{sha}"
+    candidate = base
+    suffix = 1
+    while (output_root / candidate).exists():
+        candidate = f"{base}_{suffix:02d}"
+        suffix += 1
+    return candidate
+
+
+def _parse_seeds(raw: str) -> list[int]:
+    seeds = []
+    for chunk in raw.split(","):
+        value = chunk.strip()
+        if not value:
+            continue
+        seeds.append(int(value))
+    if not seeds:
+        raise ValueError("At least one seed must be provided")
+    return seeds
+
+
+def _git_commit(*, short: bool) -> str:
+    command = ["git", "rev-parse", "--short" if short else "HEAD"]
+    result = subprocess.run(
+        command,
+        cwd=str(REPO_ROOT),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    value = result.stdout.strip()
+    return value or "unknown"
+
+
+def _format_command(command: Sequence[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(list(command))
+    return shlex.join(list(command))
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _read_tail(path: Path, lines: int = 20) -> str:
+    if not path.exists():
+        return ""
+    content = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    if not content:
+        return ""
+    return "\n".join(content[-lines:])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/aigc_detection/data/manifest.py
+++ b/src/aigc_detection/data/manifest.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .schema import (
@@ -59,18 +59,17 @@ def _normalize_record(
         )
 
     label = _coerce_label(record["label"], line_number)
-    image_path = _resolve_existing_path(
-        record["image_path"], manifest_dir, "image_path", line_number
-    )
-    mask_path = _resolve_optional_path(
-        record.get("mask_path"), manifest_dir, "mask_path", line_number
-    )
-
     meta = record.get("meta") or {}
     if not isinstance(meta, dict):
         raise ManifestValidationError(
             f"meta must be an object at line {line_number}, got {type(meta).__name__}"
         )
+    image_path = _resolve_existing_path(
+        record["image_path"], manifest_dir, "image_path", line_number, meta=meta
+    )
+    mask_path = _resolve_optional_path(
+        record.get("mask_path"), manifest_dir, "mask_path", line_number, meta=meta
+    )
 
     return NormalizedSample(
         sample_id=_require_string(record["sample_id"], "sample_id", line_number),
@@ -141,21 +140,102 @@ def _optional_string(value: Any, field_name: str, line_number: int) -> str | Non
 
 
 def _resolve_existing_path(
-    raw_value: Any, manifest_dir: Path, field_name: str, line_number: int
+    raw_value: Any,
+    manifest_dir: Path,
+    field_name: str,
+    line_number: int,
+    *,
+    meta: dict[str, Any] | None = None,
 ) -> Path:
     raw_path = _require_string(raw_value, field_name, line_number)
-    path = (manifest_dir / raw_path).resolve()
-    if not path.exists():
-        raise ManifestValidationError(
-            f"{field_name} does not exist at line {line_number}: {path}"
-        )
-    return path
+    candidate_paths: list[Path] = []
+
+    raw_path_obj = Path(raw_path)
+    if raw_path_obj.is_absolute():
+        candidate_paths.append(raw_path_obj.resolve())
+    else:
+        candidate_paths.append((manifest_dir / raw_path_obj).resolve())
+
+    remapped_path = _remap_missing_path(
+        raw_value=raw_path,
+        raw_path=raw_path_obj,
+        manifest_dir=manifest_dir,
+        meta=meta,
+    )
+    if remapped_path is not None:
+        candidate_paths.append(remapped_path)
+
+    for path in candidate_paths:
+        if path.exists():
+            return path
+
+    raise ManifestValidationError(
+        f"{field_name} does not exist at line {line_number}: {candidate_paths[0]}"
+    )
 
 
 def _resolve_optional_path(
-    raw_value: Any, manifest_dir: Path, field_name: str, line_number: int
+    raw_value: Any,
+    manifest_dir: Path,
+    field_name: str,
+    line_number: int,
+    *,
+    meta: dict[str, Any] | None = None,
 ) -> Path | None:
     if raw_value is None:
         return None
-    return _resolve_existing_path(raw_value, manifest_dir, field_name, line_number)
+    return _resolve_existing_path(
+        raw_value,
+        manifest_dir,
+        field_name,
+        line_number,
+        meta=meta,
+    )
+
+
+def _remap_missing_path(
+    *,
+    raw_value: str,
+    raw_path: Path,
+    manifest_dir: Path,
+    meta: dict[str, Any] | None,
+) -> Path | None:
+    if not isinstance(meta, dict):
+        return None
+
+    source_root_raw = meta.get("source_root")
+    if not isinstance(source_root_raw, str) or not source_root_raw.strip():
+        return None
+
+    source_root_text = source_root_raw.strip()
+    source_root_parts = [
+        part for part in PurePosixPath(source_root_text).parts if part not in {"/", "\\"}
+    ]
+    layout_suffixes: list[tuple[str, ...]] = []
+    for size in range(min(3, len(source_root_parts)), 0, -1):
+        suffix = tuple(source_root_parts[-size:])
+        if suffix not in layout_suffixes:
+            layout_suffixes.append(suffix)
+
+    try:
+        if raw_value.startswith(("/", "\\")) or source_root_text.startswith(("/", "\\")):
+            relative_suffix = PurePosixPath(raw_value).relative_to(PurePosixPath(source_root_text))
+            relative_parts = relative_suffix.parts
+        else:
+            source_root = Path(source_root_text)
+            relative_suffix = raw_path.relative_to(source_root)
+            relative_parts = relative_suffix.parts
+    except ValueError:
+        return None
+
+    for ancestor in (manifest_dir, *manifest_dir.parents):
+        for layout_suffix in layout_suffixes:
+            candidate_root = ancestor.joinpath(*layout_suffix)
+            if not candidate_root.is_dir():
+                continue
+            candidate_path = candidate_root.joinpath(*relative_parts).resolve()
+            if candidate_path.exists():
+                return candidate_path
+
+    return None
 

--- a/src/aigc_detection/eval/m4_audit.py
+++ b/src/aigc_detection/eval/m4_audit.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import json
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+NUMERIC_METRICS = (
+    "overall_accuracy",
+    "overall_auroc",
+    "overall_fake_recall",
+    "background_fake_recall",
+    "stuff_fake_recall",
+    "small_fake_recall",
+    "medium_fake_recall",
+    "large_fake_recall",
+)
+
+
+def load_reference_artifacts(eval_dir: str | Path) -> dict[str, Any]:
+    eval_dir = Path(eval_dir).resolve()
+    summary = _read_json(eval_dir / "summary.json")
+    localized = _read_json(eval_dir / "localized_failure_summary.json")
+    extracted = _extract_metrics(summary, localized)
+    return {
+        "evaluation_scope": summary.get("evaluation_scope"),
+        "sample_count": summary.get("inputs", {}).get("sample_count"),
+        "summary_path": str(eval_dir / "summary.json"),
+        "localized_summary_path": str(eval_dir / "localized_failure_summary.json"),
+        "overall": extracted["overall"],
+        "slices": extracted["slices"],
+        "subtlety": extracted["subtlety"],
+        "slice_support": _extract_slice_support(localized),
+    }
+
+
+def load_seed_metrics(eval_dir: str | Path) -> dict[str, Any]:
+    eval_dir = Path(eval_dir).resolve()
+    summary = _read_json(eval_dir / "summary.json")
+    localized = _read_json(eval_dir / "localized_failure_summary.json")
+    extracted = _extract_metrics(summary, localized)
+    return {
+        "evaluation_scope": summary.get("evaluation_scope"),
+        "sample_count": summary.get("inputs", {}).get("sample_count"),
+        "summary_path": str(eval_dir / "summary.json"),
+        "localized_summary_path": str(eval_dir / "localized_failure_summary.json"),
+        "overall": extracted["overall"],
+        "slices": extracted["slices"],
+        "subtlety": extracted["subtlety"],
+    }
+
+
+def aggregate_seed_audit(
+    *,
+    run_id: str,
+    manifest_path: str | Path,
+    output_root: str | Path,
+    reference: Mapping[str, Any],
+    seed_runs: Sequence[Mapping[str, Any]],
+    baseline_eval_dir: str | Path,
+    baseline_predictions_path: str | Path,
+) -> dict[str, Any]:
+    successful_runs = [run for run in seed_runs if run.get("status") == "success"]
+    failed_runs = [run for run in seed_runs if run.get("status") != "success"]
+    if not successful_runs:
+        raise ValueError("Cannot aggregate multi-seed audit without a successful seed.")
+
+    numeric_metrics: dict[str, Any] = {}
+    for metric_name in NUMERIC_METRICS:
+        baseline_value = _metric_value(reference, metric_name)
+        seed_values = [_metric_value(run["metrics"], metric_name) for run in successful_runs]
+        numeric_metrics[metric_name] = _summarize_numeric_series(baseline_value, seed_values)
+
+    subtlety_values = [run["metrics"]["subtlety"]["status"] for run in successful_runs]
+    subtlety_counts = dict(sorted(Counter(subtlety_values).items()))
+    return {
+        "run_id": run_id,
+        "scope": reference.get("evaluation_scope"),
+        "manifest_path": str(Path(manifest_path).resolve()),
+        "output_root": str(Path(output_root).resolve()),
+        "baseline": {
+            "eval_dir": str(Path(baseline_eval_dir).resolve()),
+            "predictions_path": str(Path(baseline_predictions_path).resolve()),
+            "reference": reference,
+        },
+        "seed_runs": list(seed_runs),
+        "status": {
+            "total_seeds": len(seed_runs),
+            "successful_seeds": len(successful_runs),
+            "failed_seeds": len(failed_runs),
+            "failed_seed_ids": [run.get("seed") for run in failed_runs],
+        },
+        "aggregate": {
+            "numeric_metrics": numeric_metrics,
+            "subtlety": {
+                "baseline": reference["subtlety"]["status"],
+                "local_statuses": subtlety_values,
+                "local_status_counts": subtlety_counts,
+                "all_same": len(subtlety_counts) == 1,
+            },
+        },
+    }
+
+
+def render_aggregate_markdown(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "# M4 Multi-Seed Local Probe Audit",
+        "",
+        f"- Run ID: `{summary['run_id']}`",
+        f"- Scope: `{summary.get('scope')}`",
+        f"- Manifest: `{summary['manifest_path']}`",
+        f"- Output root: `{summary['output_root']}`",
+        f"- Successful seeds: `{summary['status']['successful_seeds']}` / `{summary['status']['total_seeds']}`",
+        f"- Failed seeds: `{summary['status']['failed_seeds']}`",
+        "",
+        "## Baseline Reference",
+        f"- Baseline eval dir: `{summary['baseline']['eval_dir']}`",
+        f"- Baseline predictions: `{summary['baseline']['predictions_path']}`",
+        f"- Baseline evaluation scope: `{summary['baseline']['reference']['evaluation_scope']}`",
+        f"- Baseline sample count: `{summary['baseline']['reference']['sample_count']}`",
+        "",
+        "## Aggregate Metrics",
+        "| Metric | Baseline | Local mean | Delta mean | Local std | Local min | Local max | Improved seeds |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for metric_name in NUMERIC_METRICS:
+        metric = summary["aggregate"]["numeric_metrics"][metric_name]
+        lines.append(
+            "| {metric} | {baseline:.6f} | {mean:.6f} | {delta:.6f} | {std:.6f} | {minv:.6f} | {maxv:.6f} | {improved}/{total} |".format(
+                metric=metric_name,
+                baseline=metric["baseline"],
+                mean=metric["local_mean"],
+                delta=metric["delta_mean"],
+                std=metric["local_std"],
+                minv=metric["local_min"],
+                maxv=metric["local_max"],
+                improved=metric["improved_seed_count"],
+                total=metric["seed_count"],
+            )
+        )
+
+    subtlety = summary["aggregate"]["subtlety"]
+    lines.extend(
+        [
+            "",
+            "## Subtlety Status",
+            f"- Baseline: `{subtlety['baseline']}`",
+            f"- Local statuses: `{subtlety['local_statuses']}`",
+            f"- Status counts: `{subtlety['local_status_counts']}`",
+            f"- All same: `{subtlety['all_same']}`",
+            "",
+            "## Seed Outcomes",
+        ]
+    )
+    for run in summary["seed_runs"]:
+        lines.append(
+            f"- seed `{run['seed']}`: `{run['status']}`"
+            + (f" ({run.get('error')})" if run.get("error") else "")
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_run_status_markdown(summary: Mapping[str, Any]) -> str:
+    lines = [
+        "# M4 Multi-Seed Run Status",
+        "",
+        f"- Run ID: `{summary['run_id']}`",
+        f"- Scope: `{summary.get('scope')}`",
+        f"- Manifest: `{summary['manifest_path']}`",
+        f"- Output root: `{summary['output_root']}`",
+        "",
+        "## Seed Table",
+        "| Seed | Status | Export | Eval | Duration (s) | Error | Output dir |",
+        "| --- | --- | --- | --- | ---: | --- | --- |",
+    ]
+    for run in summary["seed_runs"]:
+        stages = run.get("stages", {})
+        lines.append(
+            "| {seed} | {status} | {export} | {eval_status} | {duration:.2f} | {error} | `{output_dir}` |".format(
+                seed=run["seed"],
+                status=run["status"],
+                export=stages.get("export", "-"),
+                eval_status=stages.get("eval", "-"),
+                duration=float(run.get("duration_seconds", 0.0) or 0.0),
+                error=(run.get("error") or "-").replace("\n", " "),
+                output_dir=run["output_dir"],
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Aggregate",
+            f"- Successful seeds: `{summary['status']['successful_seeds']}`",
+            f"- Failed seeds: `{summary['status']['failed_seeds']}`",
+            f"- Failed seed IDs: `{summary['status']['failed_seed_ids']}`",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _extract_metrics(summary: Mapping[str, Any], localized: Mapping[str, Any]) -> dict[str, Any]:
+    overall = dict(summary.get("report", {}).get("overall", {}).get("metrics", {}))
+    return {
+        "overall": overall,
+        "slices": {
+            "background": dict(localized["by_region_type"]["groups"]["background"]),
+            "stuff": dict(localized["by_region_type"]["groups"]["stuff"]),
+            "small": dict(localized["by_edit_area_ratio"]["groups"]["small"]),
+            "medium": dict(localized["by_edit_area_ratio"]["groups"]["medium"]),
+            "large": dict(localized["by_edit_area_ratio"]["groups"]["large"]),
+        },
+        "subtlety": dict(localized.get("subtlety", {})),
+    }
+
+
+def _extract_slice_support(localized: Mapping[str, Any]) -> dict[str, Any]:
+    def _support(group: Mapping[str, Any]) -> dict[str, Any]:
+        support = dict(group.get("support", {}))
+        return {
+            "sample_count": group.get("sample_count"),
+            "low_support": support.get("low_support"),
+            "low_support_reasons": support.get("low_support_reasons", []),
+        }
+
+    return {
+        "background": _support(localized["by_region_type"]["groups"]["background"]),
+        "stuff": _support(localized["by_region_type"]["groups"]["stuff"]),
+        "small": _support(localized["by_edit_area_ratio"]["groups"]["small"]),
+        "medium": _support(localized["by_edit_area_ratio"]["groups"]["medium"]),
+        "large": _support(localized["by_edit_area_ratio"]["groups"]["large"]),
+        "subtlety": dict(localized.get("subtlety", {})),
+    }
+
+
+def _metric_value(metrics: Mapping[str, Any], metric_name: str) -> float | str:
+    if metric_name.startswith("overall_"):
+        return float(metrics["overall"][metric_name.removeprefix("overall_")])
+    if metric_name.endswith("_fake_recall"):
+        slice_name = metric_name.removesuffix("_fake_recall")
+        return float(metrics["slices"][slice_name]["metrics"]["fake_recall"])
+    raise KeyError(f"Unsupported metric name: {metric_name}")
+
+
+def _summarize_numeric_series(baseline: float, values: Sequence[float]) -> dict[str, Any]:
+    local_values = [float(value) for value in values]
+    if not local_values:
+        raise ValueError("Cannot summarize an empty metric series.")
+    improved = sum(1 for value in local_values if value > baseline)
+    worsened = sum(1 for value in local_values if value < baseline)
+    unchanged = len(local_values) - improved - worsened
+    local_mean = statistics.fmean(local_values)
+    local_std = statistics.stdev(local_values) if len(local_values) > 1 else 0.0
+    return {
+        "baseline": float(baseline),
+        "local_values": local_values,
+        "local_mean": local_mean,
+        "delta_mean": local_mean - baseline,
+        "local_std": local_std,
+        "local_min": min(local_values),
+        "local_max": max(local_values),
+        "seed_count": len(local_values),
+        "improved_seed_count": improved,
+        "worsened_seed_count": worsened,
+        "unchanged_seed_count": unchanged,
+        "improved_fraction": improved / len(local_values),
+    }
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Missing audit artifact: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))

--- a/tests/test_community_forensics_export.py
+++ b/tests/test_community_forensics_export.py
@@ -15,7 +15,14 @@ from PIL import Image
 from aigc_detection.data import load_manifest
 
 
+_EXPORT_MODULE = None
+
+
 def _load_export_module():
+    global _EXPORT_MODULE
+    if _EXPORT_MODULE is not None:
+        return _EXPORT_MODULE
+
     script_path = Path(__file__).resolve().parents[1] / "scripts" / "export_community_forensics_predictions.py"
     spec = importlib.util.spec_from_file_location("test_export_community_forensics_predictions", script_path)
     if spec is None or spec.loader is None:
@@ -39,10 +46,32 @@ def _load_export_module():
         },
     ):
         spec.loader.exec_module(module)
+    _EXPORT_MODULE = module
     return module
 
 
 class CommunityForensicsExportTests(unittest.TestCase):
+    def test_build_parser_exposes_local_module_flags(self) -> None:
+        export_module = _load_export_module()
+
+        args = export_module.build_parser().parse_args(
+            [
+                "--manifest",
+                "manifest.jsonl",
+                "--output",
+                "predictions.jsonl",
+                "--use-local-module",
+                "--local-module-config",
+                "configs/model/local_module.yaml",
+                "--progress-every",
+                "25",
+            ]
+        )
+
+        self.assertTrue(args.use_local_module)
+        self.assertEqual(args.local_module_config, "configs/model/local_module.yaml")
+        self.assertEqual(args.progress_every, 25)
+
     def test_manifest_image_dataset_applies_optional_perturbation(self) -> None:
         export_module = _load_export_module()
 
@@ -107,6 +136,64 @@ class CommunityForensicsExportTests(unittest.TestCase):
 
             self.assertTrue(np.array_equal(clean_item[0], np.asarray(Image.open(image_path).convert("RGB"))))
             self.assertFalse(np.array_equal(clean_item[0], jpeg_item[0]))
+
+    def test_load_model_forwards_local_module_config_only_when_enabled(self) -> None:
+        export_module = _load_export_module()
+
+        calls = []
+
+        class _DummyLoadedModel:
+            def __init__(self) -> None:
+                self.to_calls = []
+                self.eval_called = False
+
+            def to(self, device):
+                self.to_calls.append(device)
+                return self
+
+            def eval(self):
+                self.eval_called = True
+                return self
+
+        class _FakeViTClassifier:
+            @classmethod
+            def from_pretrained(cls, *args, **kwargs):
+                calls.append(kwargs.copy())
+                return _DummyLoadedModel()
+
+        fake_models = types.ModuleType("models")
+        fake_models.ViTClassifier = _FakeViTClassifier
+
+        with patch.dict(sys.modules, {"models": fake_models}):
+            baseline_model = export_module._load_model(
+                hf_model_repo="repo-a",
+                model_size="small",
+                input_size=384,
+                patch_size=16,
+                device="cpu",
+                use_local_module=False,
+                local_module_config=None,
+            )
+            local_model = export_module._load_model(
+                hf_model_repo="repo-b",
+                model_size="small",
+                input_size=384,
+                patch_size=16,
+                device="cpu",
+                use_local_module=True,
+                local_module_config={"type": "topk", "k": 8},
+            )
+
+        self.assertIsInstance(baseline_model, _DummyLoadedModel)
+        self.assertIsInstance(local_model, _DummyLoadedModel)
+        self.assertEqual(calls[0]["use_local_module"], False)
+        self.assertIsNone(calls[0]["local_module_config"])
+        self.assertEqual(calls[1]["use_local_module"], True)
+        self.assertEqual(calls[1]["local_module_config"], {"type": "topk", "k": 8})
+        self.assertEqual(baseline_model.to_calls, ["cpu"])
+        self.assertTrue(baseline_model.eval_called)
+        self.assertEqual(local_model.to_calls, ["cpu"])
+        self.assertTrue(local_model.eval_called)
 
 
 if __name__ == "__main__":

--- a/tests/test_m4_audit.py
+++ b/tests/test_m4_audit.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from aigc_detection.eval.m4_audit import (
+    aggregate_seed_audit,
+    load_reference_artifacts,
+    load_seed_metrics,
+    render_aggregate_markdown,
+    render_run_status_markdown,
+)
+
+
+def _write_reference_artifacts(root: Path) -> Path:
+    eval_dir = root / "eval"
+    eval_dir.mkdir(parents=True, exist_ok=True)
+    summary = {
+        "evaluation_scope": "restricted_pilot",
+        "inputs": {"sample_count": 100},
+        "report": {
+            "overall": {
+                "metrics": {
+                    "accuracy": 0.50,
+                    "auroc": 0.70,
+                    "fake_recall": 0.40,
+                }
+            }
+        },
+    }
+    localized = {
+        "subtlety": {"status": "blocked", "reason": "missing"},
+        "by_region_type": {
+            "groups": {
+                "background": {
+                    "sample_count": 50,
+                    "support": {"low_support": False, "low_support_reasons": []},
+                    "metrics": {"accuracy": 0.80, "auroc": 0.90, "fake_recall": 0.75},
+                },
+                "stuff": {
+                    "sample_count": 50,
+                    "support": {"low_support": False, "low_support_reasons": []},
+                    "metrics": {"accuracy": 0.30, "auroc": 0.60, "fake_recall": 0.20},
+                },
+            }
+        },
+        "by_edit_area_ratio": {
+            "groups": {
+                "small": {
+                    "sample_count": 10,
+                    "support": {"low_support": False, "low_support_reasons": []},
+                    "metrics": {"accuracy": 0.20, "auroc": 0.50, "fake_recall": 0.10},
+                },
+                "medium": {
+                    "sample_count": 20,
+                    "support": {"low_support": False, "low_support_reasons": []},
+                    "metrics": {"accuracy": 0.25, "auroc": 0.55, "fake_recall": 0.15},
+                },
+                "large": {
+                    "sample_count": 70,
+                    "support": {"low_support": False, "low_support_reasons": []},
+                    "metrics": {"accuracy": 0.60, "auroc": 0.85, "fake_recall": 0.60},
+                },
+            }
+        },
+    }
+    (eval_dir / "summary.json").write_text(json.dumps(summary), encoding="utf-8")
+    (eval_dir / "localized_failure_summary.json").write_text(json.dumps(localized), encoding="utf-8")
+    return eval_dir
+
+
+class M4AuditTests(unittest.TestCase):
+    def test_load_reference_and_seed_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            eval_dir = _write_reference_artifacts(Path(tmp_dir))
+            reference = load_reference_artifacts(eval_dir)
+            seed_metrics = load_seed_metrics(eval_dir)
+
+            self.assertEqual(reference["evaluation_scope"], "restricted_pilot")
+            self.assertEqual(reference["sample_count"], 100)
+            self.assertAlmostEqual(reference["overall"]["accuracy"], 0.50)
+            self.assertAlmostEqual(reference["slices"]["background"]["metrics"]["fake_recall"], 0.75)
+            self.assertEqual(reference["subtlety"]["status"], "blocked")
+            self.assertFalse(reference["slice_support"]["stuff"]["low_support"])
+            self.assertEqual(seed_metrics["slices"]["small"]["metrics"]["fake_recall"], 0.10)
+
+    def test_aggregate_seed_audit_and_renderers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            eval_dir = _write_reference_artifacts(root)
+            reference = load_reference_artifacts(eval_dir)
+            seed_runs = [
+                {
+                    "seed": 0,
+                    "status": "success",
+                    "output_dir": str(root / "seed_000"),
+                    "stages": {"export": "success", "eval": "success"},
+                    "duration_seconds": 10.0,
+                    "metrics": {
+                        "overall": {"accuracy": 0.52, "auroc": 0.71, "fake_recall": 0.41},
+                        "slices": {
+                            "background": {"metrics": {"fake_recall": 0.76}},
+                            "stuff": {"metrics": {"fake_recall": 0.21}},
+                            "small": {"metrics": {"fake_recall": 0.11}},
+                            "medium": {"metrics": {"fake_recall": 0.16}},
+                            "large": {"metrics": {"fake_recall": 0.61}},
+                        },
+                        "subtlety": {"status": "blocked"},
+                    },
+                },
+                {
+                    "seed": 1,
+                    "status": "success",
+                    "output_dir": str(root / "seed_001"),
+                    "stages": {"export": "success", "eval": "success"},
+                    "duration_seconds": 11.0,
+                    "metrics": {
+                        "overall": {"accuracy": 0.54, "auroc": 0.73, "fake_recall": 0.43},
+                        "slices": {
+                            "background": {"metrics": {"fake_recall": 0.77}},
+                            "stuff": {"metrics": {"fake_recall": 0.19}},
+                            "small": {"metrics": {"fake_recall": 0.12}},
+                            "medium": {"metrics": {"fake_recall": 0.14}},
+                            "large": {"metrics": {"fake_recall": 0.59}},
+                        },
+                        "subtlety": {"status": "blocked"},
+                    },
+                },
+                {
+                    "seed": 2,
+                    "status": "failed",
+                    "output_dir": str(root / "seed_002"),
+                    "stages": {"export": "failed", "eval": "pending"},
+                    "duration_seconds": 3.0,
+                    "error": "boom",
+                },
+            ]
+
+            summary = aggregate_seed_audit(
+                run_id="run-123",
+                manifest_path=root / "manifest.jsonl",
+                output_root=root,
+                reference=reference,
+                seed_runs=seed_runs,
+                baseline_eval_dir=eval_dir,
+                baseline_predictions_path=root / "baseline.jsonl",
+            )
+
+            self.assertEqual(summary["status"]["successful_seeds"], 2)
+            self.assertEqual(summary["status"]["failed_seed_ids"], [2])
+            self.assertAlmostEqual(summary["aggregate"]["numeric_metrics"]["overall_accuracy"]["local_mean"], 0.53)
+            self.assertAlmostEqual(summary["aggregate"]["numeric_metrics"]["stuff_fake_recall"]["delta_mean"], 0.0)
+            self.assertEqual(summary["aggregate"]["subtlety"]["baseline"], "blocked")
+
+            markdown = render_aggregate_markdown(summary)
+            self.assertIn("M4 Multi-Seed Local Probe Audit", markdown)
+            self.assertIn("overall_accuracy", markdown)
+            self.assertIn("seed `2`: `failed`", markdown)
+
+            status_md = render_run_status_markdown(summary)
+            self.assertIn("Error", status_md)
+            self.assertIn("boom", status_md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifest_loader.py
+++ b/tests/test_manifest_loader.py
@@ -74,6 +74,98 @@ class ManifestLoaderTests(unittest.TestCase):
             with self.assertRaises(ManifestValidationError):
                 load_manifest(manifest_path)
 
+    def test_remaps_stale_absolute_paths_via_source_root_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            current_source_root = root / "data" / "BR-Gen"
+            image_path = current_source_root / "Forged" / "BrushNet" / "Background" / "COCO" / "000000000034_background.png"
+            mask_path = current_source_root / "Mask" / "Background" / "COCO" / "000000000034_background.png"
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            mask_path.parent.mkdir(parents=True, exist_ok=True)
+            image_path.write_text("image", encoding="utf-8")
+            mask_path.write_text("mask", encoding="utf-8")
+
+            manifest_dir = root / "data" / "mirrored" / "br_gen" / "subsets" / "restricted_pilot" / "manifest"
+            manifest_dir.mkdir(parents=True, exist_ok=True)
+            manifest_path = manifest_dir / "formal_manifest.jsonl"
+            stale_source_root = "/home/workspace/AIGC/data/BRGen/BR-Gen"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "sample_id": "fake__brushnet__background__coco__000000000034_background__blur",
+                        "task_type": "localized_edit",
+                        "split": "restricted_pilot",
+                        "image_path": f"{stale_source_root}/Forged/BrushNet/Background/COCO/000000000034_background.png",
+                        "label": 1,
+                        "mask_path": f"{stale_source_root}/Mask/Background/COCO/000000000034_background.png",
+                        "generator_id": "BrushNet",
+                        "source_id": "COCO",
+                        "degradation": "blur",
+                        "region_type": "background",
+                        "meta": {
+                            "source_root": stale_source_root,
+                            "relative_path": "BrushNet/Background/COCO/000000000034_background.png",
+                            "evaluation_scope": "restricted_pilot",
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            samples = load_manifest(manifest_path)
+
+            self.assertEqual(len(samples), 1)
+            self.assertEqual(samples[0].image_path, image_path.resolve())
+            self.assertEqual(samples[0].mask_path, mask_path.resolve())
+            self.assertTrue(samples[0].image_path.exists())
+            self.assertTrue(samples[0].mask_path.exists())
+
+    def test_remaps_stale_absolute_paths_through_brgen_parent_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            current_source_root = root / "data" / "BRGen" / "BR-Gen"
+            image_path = current_source_root / "Forged" / "BrushNet" / "Background" / "COCO" / "000000000034_background.png"
+            mask_path = current_source_root / "Mask" / "Background" / "COCO" / "000000000034_background.png"
+            image_path.parent.mkdir(parents=True, exist_ok=True)
+            mask_path.parent.mkdir(parents=True, exist_ok=True)
+            image_path.write_text("image", encoding="utf-8")
+            mask_path.write_text("mask", encoding="utf-8")
+
+            manifest_dir = root / "data" / "mirrored" / "br_gen" / "subsets" / "restricted_pilot" / "manifest"
+            manifest_dir.mkdir(parents=True, exist_ok=True)
+            manifest_path = manifest_dir / "formal_manifest.jsonl"
+            stale_source_root = "/home/workspace/AIGC/data/BRGen/BR-Gen"
+            manifest_path.write_text(
+                json.dumps(
+                    {
+                        "sample_id": "fake__brushnet__background__coco__000000000034_background__blur",
+                        "task_type": "localized_edit",
+                        "split": "restricted_pilot",
+                        "image_path": f"{stale_source_root}/Forged/BrushNet/Background/COCO/000000000034_background.png",
+                        "label": 1,
+                        "mask_path": f"{stale_source_root}/Mask/Background/COCO/000000000034_background.png",
+                        "generator_id": "BrushNet",
+                        "source_id": "COCO",
+                        "degradation": "blur",
+                        "region_type": "background",
+                        "meta": {
+                            "source_root": stale_source_root,
+                            "relative_path": "BrushNet/Background/COCO/000000000034_background.png",
+                            "evaluation_scope": "restricted_pilot",
+                        },
+                    }
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            samples = load_manifest(manifest_path)
+
+            self.assertEqual(len(samples), 1)
+            self.assertEqual(samples[0].image_path, image_path.resolve())
+            self.assertEqual(samples[0].mask_path, mask_path.resolve())
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR closes out M4 as a COCO-only restricted-pilot engineering line and packages the final local-evidence probe evidence.

What changed:
- Added the no-train local evidence module and its wrapper integration on top of the verified Community Forensics path.
- Added the multi-seed audit runner and audit helpers for seed-stability tracking.
- Recorded the final restricted-pilot results, review, handoff, and closeout docs.
- Updated the M4 milestone / issue GitHub docs and repository run-order notes.
- Kept the baseline path intact and preserved the restricted-pilot contract.

What the evidence shows:
- The local probe produces a small but consistent positive shift on the blind-spot slices across 5 seeds.
- `stuff`, `small`, and `medium` all move in the same direction across seeds.
- `background` remains stable and easy.
- The result is seed-stable diagnostic evidence, not a formal benchmark claim.

Validation:
- `python -m unittest discover -s tests -p "test_community_forensics_export.py" -v`
- `python -m unittest discover -s tests -p "test_m4_audit.py" -v`
- `python -m unittest discover -s tests -p "test_manifest_loader.py" -v`
- Multi-seed audit completed successfully at `outputs/m4/multi_seed_audit/m4_multi_seed_20260403T024452Z_unknown/`

Scope notes:
- This PR stays inside the COCO-only restricted-pilot line.
- It does not add training, ImageNet / Places negatives, or a benchmark claim.
- Remaining M5 / M5b work is intentionally left out of this PR.