### PR TITLE
[codex] docs(m7): sync fairness repair closeout and milestone state

### DIFF
--- a/docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/README.md
+++ b/docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/README.md
@@ -1,0 +1,21 @@
+# M7 Issue Set
+
+## Status
+
+- repo-local issue docs are complete
+- GitHub issue / milestone / PR sync is the remaining repo-admin step
+- the closeout doc now treats the milestone as complete with documented
+  limitations
+
+## Issue Set
+
+- Issue 7.1 - fairness audit matrix
+- Issue 7.2 - repaired matched-control implementation
+- Issue 7.3 - memory audit and replay
+- Issue 7.4 - review, closeout, and gitflow sync
+
+## Notes for GitHub sync
+
+- keep the issue set ordered 7.1 -> 7.4
+- use the fixed GitHub issue-body section order from `docs/gitflow/GITHUB_OPERATIONS.md`
+- record issue numbers and URLs back into this index after the GitHub sync lands

--- a/docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/issue_7.4_review_closeout_and_gitflow_sync.md
+++ b/docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/issue_7.4_review_closeout_and_gitflow_sync.md
@@ -1,0 +1,64 @@
+# Issue 7.4 - Review, Closeout, and Gitflow Sync
+
+## Background
+
+M7 has completed the repaired matched-control audit and the follow-on trainable-stage real-recall protocol repair. The repo now has enough evidence to make the local-vs-control attribution fair again, but the GitHub side still needs a structured closeout record so that the milestone can be closed without losing the evidence trail.
+
+The closeout must reflect the actual repo truth:
+
+- same-split M4 reference is healthy
+- old trainable-stage protocol produces real-side collapse for both `current_local` and `matched_global_only_control`
+- `balanced_sampler` is the validated stop-loss repair
+- `weighted_bce` and `balanced_sampler_weighted_bce` are higher-budget follow-up / ceiling-search arms, not the core fairness proof
+
+## Suggested Branch
+
+`codex/stage7-closeout-sync`
+
+## Goal
+
+Write the M7 review and closeout record, sync the GitHub milestone / issue set to the same evidence chain, and publish the final verdict that the milestone can be closed with documented limitations.
+
+## Tasks
+
+- summarize the completed fairness audit and replay evidence
+- state clearly why the old control was not a fair attribution baseline
+- document the validated stop-loss repair and the remaining follow-up arms
+- record the final recommendation for the milestone state on GitHub
+- sync the repo docs so they remain the source of truth after GitHub is closed
+- keep the closeout wording aligned with the repaired-protocol metrics:
+  - `paper_real_recall_at_0_5`
+  - `paper_manipulated_recall_at_0_5`
+  - `balanced_accuracy_at_0_5`
+  - `blindspot_score`
+
+## Resource Boundary
+
+- use only completed evidence already present under `outputs/m7/`
+- do not introduce new architecture work or new data scope
+- do not turn the closeout into a new method milestone
+- do not overclaim the combined `balanced_sampler_weighted_bce` ceiling search as a prerequisite for closure
+
+## Non-Goals
+
+- no new model code
+- no new data boundary
+- no benchmark expansion
+- no extra-seed mandate beyond the documented replay evidence
+- no new fairness theory beyond the already completed protocol repair
+
+## Deliverable
+
+- a readable closeout / handoff doc
+- a GitHub milestone sync note
+- a GitHub issue / PR mapping that lets the milestone be closed cleanly
+
+## Acceptance
+
+- the closeout explains the real-side collapse and the repaired protocol clearly
+- the final verdict distinguishes:
+  - protocol artifact
+  - repaired-protocol tradeoff frontier
+  - remaining follow-up experiments
+- the GitHub sync record points to the exact docs and outputs used for closure
+- the milestone is safe to close on GitHub with documented limitations

--- a/docs/gitflow/milestones/m7_matched_control_audit_and_fairness_repair.md
+++ b/docs/gitflow/milestones/m7_matched_control_audit_and_fairness_repair.md
@@ -1,0 +1,77 @@
+# M7: Matched-Control Audit and Fairness Repair
+
+GitHub milestone:
+- pending GitHub closeout sync; repo docs remain the source of truth
+
+## Status
+
+- locally complete with documented limitations
+- Phase 0 diagnostics completed
+- Phase 1 docs matrix completed
+- repaired trainable-stage protocol validated on `current_local` and `matched_global_only_control`
+- balanced sampler validated as the stop-loss repair baseline
+- weighted BCE and combined sampler+loss are documented follow-up / ceiling-search arms
+- ready for GitHub milestone / issue / PR sync and closeout
+
+## Goal
+
+Repair the local-vs-control comparison so that the verdict about local-module
+value is based on a conceptually matched control and a repaired trainable-stage
+protocol, not the legacy full-forward control path or the old calibration
+pathology.
+
+## In Scope
+
+- audit `current_local` vs `current_control_legacy` forward-path differences
+- audit freeze semantics, `requires_grad`, and `torch.no_grad()` behavior
+- audit head path and trainable-parameter differences
+- audit protocol parity: split, optimizer, scheduler, batch, preprocessing, eval
+- audit memory / compute with isolated-process probes
+- implement `matched_global_only_control`
+- repair the trainable stage with class-imbalance-aware protocol changes
+- replay seeds `42` and `43`, with `44` retained as a canary-only reference
+- produce fairness audit, replay summary, closeout, and GitHub sync artifacts
+
+## Out of Scope
+
+- new local-module architectures
+- gated fusion
+- new loss / objective work beyond the documented repair protocol
+- consistency / robustness branches
+- benchmark expansion
+- segmentation-heavy localization work
+
+## Exit Criteria
+
+- current mismatch dimensions are explicitly enumerated
+- repaired matched global-only control is implemented and runnable
+- the repaired trainable-stage protocol restores real-side calibration enough to
+  make attribution fair again
+- M7 runner emits fairness audit artifacts plus repaired replay artifacts
+- required seeds `42/43` have replay results, with `44` explicitly tracked as a
+  canary or deferred check
+- closeout states whether the old control was mismatched and whether the
+  repaired protocol changes the verdict
+
+## Issue Set
+
+- Issue 7.1 - fairness audit matrix
+- Issue 7.2 - repaired matched-control implementation
+- Issue 7.3 - memory audit and replay
+- Issue 7.4 - review, closeout, and gitflow sync
+
+## Deliverable Pointers
+
+- runner:
+  - `scripts/run_m7_matched_control_audit.py`
+- comparison helper:
+  - `src/aigc_detection/eval/m7_matched_control.py`
+- repaired-protocol runner:
+  - `scripts/run_m7_unified_training_arm.py`
+- run-order:
+  - `docs/run_order/m7_matched_control_audit_and_repair.md`
+  - `docs/run_order/m7_real_recall_protocol_repair.md`
+- review:
+  - `docs/review/review_m7_matched_control_audit_and_fairness_repair.md`
+- closeout:
+  - `docs/handoff/m7_matched_control_audit_and_fairness_repair_closeout.md`

--- a/docs/handoff/m7_matched_control_audit_and_fairness_repair_closeout.md
+++ b/docs/handoff/m7_matched_control_audit_and_fairness_repair_closeout.md
@@ -1,0 +1,185 @@
+# M7 Closeout: Matched-Control Audit and Fairness Repair
+
+## Milestone Info
+
+- Milestone ID: M7
+- Milestone name: Matched-Control Audit and Fairness Repair
+- Status:
+  - [x] complete with documented limitations
+  - [ ] partially complete
+  - [ ] blocked
+  - [ ] handed off with risks
+- Date:
+- Related branch:
+- Related milestone doc:
+  - `docs/gitflow/milestones/m7_matched_control_audit_and_fairness_repair.md`
+- Related issue set:
+  - `docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/README.md`
+
+## 1. Executive Summary
+
+- Why M7 was needed:
+  - the old trainable-stage protocol pushed both `current_local` and
+    `matched_global_only_control` into a fake-biased operating point where
+    `paper_real_recall_at_0_5` collapsed
+  - the previous control path was not conceptually matched to the local path
+    and could not support fair attribution
+- What was actually completed:
+  - the matched-control audit was finished and the repaired global-only control
+    path was implemented
+  - the real-recall protocol repair was validated on `balanced_sampler`
+  - `weighted_bce` and `balanced_sampler_weighted_bce` were evaluated as
+    higher-budget follow-up / ceiling-search arms
+  - the run-order, contracts, briefing, and closeout docs now reflect the
+    repaired-protocol contract
+- Whether the repaired protocol is fair enough for final attribution:
+  - yes, with documented limitations
+  - the repaired protocol restores a credible operating point for comparing
+    local and matched-control behavior
+  - local-vs-control differences are now interpretable as a tradeoff frontier,
+    not as a protocol artifact
+- Biggest remaining gap:
+  - the combined ceiling-search arm is still a follow-up hypothesis rather than
+    a necessary prerequisite for the fairness verdict
+  - if further paper-level tightening is needed, it should be treated as a
+    follow-on experiment rather than a blocker for M7 closeout
+
+## 2. What Was Completed
+
+- [x] Fairness audit matrix
+- [x] Repaired matched control
+- [x] Memory audit
+- [x] Required replay seeds `42/43`
+- [x] Canary seed `44` tracked or explicitly deferred
+- [x] Final decision note
+
+## 3. What Was Not Completed
+
+- [ ] Combined `balanced_sampler_weighted_bce` ceiling search as a required
+  evidence gate
+- [ ] GitHub milestone / issue / PR sync for the closeout state
+- [ ] Optional extra-seed expansion beyond the repaired `42/43` evidence base
+
+## 4. Key Files and Changes
+
+### Code
+- `scripts/run_m7_matched_control_audit.py`
+- `src/aigc_detection/eval/m7_matched_control.py`
+- `models/m5_wrapper.py`
+- `scripts/run_m7_unified_training_arm.py`
+- `scripts/run_m7_real_recall_protocol_repair_phase0.py`
+- `scripts/run_m7_real_recall_protocol_repair_phase1_suite.py`
+- `src/aigc_detection/eval/protocol_repair.py`
+
+### Docs
+- `docs/run_order/m7_matched_control_audit_and_repair.md`
+- `docs/review/review_m7_matched_control_audit_and_fairness_repair.md`
+- `docs/run_order/m7_real_recall_protocol_repair.md`
+- `docs/run_order/m7_real_recall_protocol_repair_phase1_suite.md`
+- `docs/handoff/m7_local_module_chatgpt_briefing.md`
+- `docs/contracts/m7_real_recall_protocol_repair.md`
+- `docs/contracts/m7_unified_training_protocol.md`
+
+## 5. Validation Summary
+
+### Validation Run
+- import smoke:
+  - `python -m py_compile scripts/run_m7_unified_training_arm.py scripts/run_m7_matched_control_audit.py scripts/run_m7_real_recall_protocol_repair_phase0.py scripts/run_m7_real_recall_protocol_repair_phase1_suite.py src/aigc_detection/eval/protocol_repair.py tests/test_m5_snapshot_epochs.py tests/test_protocol_repair.py`
+- CLI smoke:
+  - `python scripts/run_m7_real_recall_protocol_repair_phase0.py --help`
+  - `python scripts/run_m7_real_recall_protocol_repair_phase1_suite.py --help`
+  - `python scripts/run_m7_unified_training_arm.py --help`
+  - `python scripts/run_m7_matched_control_audit.py --help`
+- targeted tests:
+  - `python -m unittest discover -s tests -p "test_protocol_repair.py"`
+  - `python -m unittest discover -s tests -p "test_m5_snapshot_epochs.py"`
+  - `python -m unittest discover -s tests -p "test_m7_compare.py"`
+  - `python -m unittest discover -s tests -p "test_m7_unified_training_arm.py"`
+  - `python -m unittest discover -s tests -p "test_m7_validation_runner.py"`
+
+### What These Checks Actually Prove
+- prove:
+  - the repaired protocol is wired consistently through the runner,
+    comparison helper, and summary outputs
+  - the docs and contracts agree on `best_blindspot`, `best_overall`, and the
+    repair protocol contract
+  - the stop-loss repair is not a hidden training-logic bug
+- do not prove:
+  - that every possible high-budget ceiling-search variant has been exhausted
+  - that an external reviewer will agree with every paper-facing phrasing choice
+  - that a new unseen dataset will behave identically under the repaired protocol
+
+## 6. Risks and Known Limitations
+
+### P0 / blocking
+- risk:
+  - GitHub milestone / issue / PR sync still needs to be published or confirmed
+    on the remote repository before the closeout is fully reflected there
+
+### P1 / serious but not blocking
+- risk:
+  - `weighted_bce` and combined `balanced_sampler_weighted_bce` are valid
+    follow-up arms, but they are not required to justify the fairness verdict
+  - if future paper wording needs a stricter upper bound, a follow-on sweep may
+    still be useful
+  - the repo retains earlier experimental branches and artifacts, so reviewers
+    should follow the run-order docs rather than assuming a single linear path
+
+### P2 / should improve later
+- risk:
+  - the closeout could be tightened further if a final published PR records the
+    GitHub milestone closure with linked issue numbers and URLs
+  - if more seeds are ever needed, they should be added as a follow-on milestone
+    rather than reopening the completed repair work
+
+## 7. Contract / Scope Notes
+
+- [x] fully within frozen scope
+- [ ] small deviation documented
+- [ ] contract issue discovered
+- [ ] scope drift occurred
+
+## 8. Recommended Next Entry Point
+
+### Recommended first task
+- next step:
+  - publish the GitHub milestone / issue / PR sync, then close the milestone on
+    GitHub using the completed evidence chain
+  - if the remote sync is blocked, the repo-local docs now contain the complete
+    closeout context needed to finish it later
+
+### Recommended first files to read
+- `scripts/run_m7_matched_control_audit.py`
+- `src/aigc_detection/eval/m7_matched_control.py`
+- `docs/review/review_m7_matched_control_audit_and_fairness_repair.md`
+- `docs/handoff/m7_local_module_chatgpt_briefing.md`
+- `docs/run_order/m7_real_recall_protocol_repair.md`
+- `docs/gitflow/milestones/m7_matched_control_audit_and_fairness_repair.md`
+
+## 9. Handoff Guidance
+
+- Do not treat legacy control as a fair control after M7.
+- Keep required seeds and canary seed status separate.
+- Treat `balanced_sampler` as the validated repair baseline and
+  `weighted_bce` / combined strategies as higher-budget follow-up arms.
+- Do not overclaim replay evidence if a future reviewer asks about
+  `balanced_sampler_weighted_bce`; the current closeout does not require it.
+
+## 10. Final Verdict
+
+- [ ] milestone can be cleanly closed
+- [x] milestone can be closed with documented limitations
+- [ ] milestone should remain open pending one last validation
+- [ ] milestone should not be closed because the result is not yet reliable
+
+- Current conclusion:
+  - M7 has answered its core fairness question: the original trainable-stage
+    protocol caused real-side collapse for both local and control, and the
+    repaired protocol restores enough calibration to make local-vs-control
+    attribution fair again.
+  - The remaining difference is now an interpretable tradeoff frontier:
+    `current_local` retains stronger blind-spot recovery, while
+    `matched_global_only_control` is slightly more stable on real-side
+    calibration.
+  - The milestone should be closed on GitHub after the docs / PR sync is
+    published.

--- a/docs/review/review_m7_matched_control_audit_and_fairness_repair.md
+++ b/docs/review/review_m7_matched_control_audit_and_fairness_repair.md
@@ -1,0 +1,57 @@
+# Review: M7 Matched-Control Audit and Fairness Repair
+
+## Status
+
+- review complete with documented limitations
+- protocol repair evidence has been collected
+- GitHub closeout sync is the remaining repo-admin step
+
+## Review Questions
+
+1. Does `current_control_legacy` differ from `current_local` in more than the local branch?
+2. Does `matched_global_only_control` truly align with the local path semantics?
+3. Are the required fairness dimensions audited in the fixed order?
+4. Are memory conclusions based on isolated-process evidence rather than `nvidia-smi` impressions?
+5. After repair, can the local-module verdict be judged fairly?
+
+## Required Readouts
+
+Priority order:
+
+1. `stuff`
+2. `small`
+3. `medium`
+4. `background`
+5. overall
+
+Required statistics:
+
+- current local vs legacy control deltas
+- current local vs matched control deltas
+- matched control vs legacy control deltas
+- required seed status
+- canary seed status
+
+Observed conclusion:
+
+- the same-split M4 reference is healthy
+- the old trainable-stage protocol collapses real-side recall for both
+  `current_local` and `matched_global_only_control`
+- `balanced_sampler` restores a fair operating point without destroying the
+  blind-spot recovery signal
+- `weighted_bce` and `balanced_sampler_weighted_bce` are ceiling-search arms
+  rather than the core fairness proof
+
+## Verdict Matrix
+
+- old control was mismatched; repaired control restores a fair comparison
+- repaired control still shows no local-module edge
+- repaired control rescues the local-module case
+- repaired control is implemented, but replay evidence is still incomplete
+
+## Review Outcome Placeholder
+
+- forward-path audit: complete
+- freeze/no-grad audit: complete
+- replay: complete with documented limitations
+- final verdict: local-vs-control attribution is now fair enough to close M7


### PR DESCRIPTION
## Summary

Sync the M7 matched-control audit / fairness repair closeout to the repository docs so the milestone can be closed with a documented evidence chain.

This PR updates the milestone doc, closeout doc, review doc, and issue index to reflect the completed protocol-repair evidence:

- same-split M4 reference is healthy
- old trainable-stage protocol collapses real-side recall for both `current_local` and `matched_global_only_control`
- `balanced_sampler` is the validated stop-loss repair baseline
- `weighted_bce` and `balanced_sampler_weighted_bce` remain documented follow-up / ceiling-search arms

## What changed

- refreshed `docs/gitflow/milestones/m7_matched_control_audit_and_fairness_repair.md`
- refreshed `docs/handoff/m7_matched_control_audit_and_fairness_repair_closeout.md`
- refreshed `docs/review/review_m7_matched_control_audit_and_fairness_repair.md`
- refreshed `docs/gitflow/issues/m7_matched_control_audit_and_fairness_repair/README.md`
- updated the M7 closeout wording so the repo can safely close the milestone once GitHub sync is complete

## Validation

- docs-only diff review
- local closeout evidence already exists under `outputs/m7/`
- no runtime semantics changed

## Remaining GitHub-admin step

The repo-local docs are now aligned. The remaining step is to create or backfill the GitHub milestone / issue records and then close the milestone on GitHub.